### PR TITLE
ENH: skip loading of application-test.yaml when system property suppressTestResource is set to true

### DIFF
--- a/src/main/java/io/avaje/config/InitialLoader.java
+++ b/src/main/java/io/avaje/config/InitialLoader.java
@@ -175,6 +175,10 @@ final class InitialLoader {
    * @return true if test properties have been loaded.
    */
   private boolean loadTest() {
+
+    if (Boolean.getBoolean("suppressTestResource")) {
+      return false;
+    }
     int before = loadContext.size();
     loadProperties("application-test.properties", RESOURCE);
     loadYaml("application-test.yaml", RESOURCE);
@@ -182,7 +186,7 @@ final class InitialLoader {
       Config.log.log(Level.WARNING, "Please rename application-test.yml to application-test.yaml - Using yml suffix (rather than yaml) is deprecated.");
     }
     if (loadProperties("test-ebean.properties", RESOURCE)) {
-      Config.log.log(Level.WARNING,"Loading properties from test-ebean.properties is deprecated. Please migrate to application-test.yaml or application-test.properties instead.");
+      Config.log.log(Level.WARNING, "Loading properties from test-ebean.properties is deprecated. Please migrate to application-test.yaml or application-test.properties instead.");
     }
     return loadContext.size() > before;
   }
@@ -217,11 +221,11 @@ final class InitialLoader {
   private void loadMain(Source source) {
     loadYaml("application.yaml", source);
     if (loadYaml("application.yml", source)) {
-      Config.log.log(Level.WARNING,"Please rename application.yml to application.yaml - Using yml suffix (rather than yaml) is deprecated.");
+      Config.log.log(Level.WARNING, "Please rename application.yml to application.yaml - Using yml suffix (rather than yaml) is deprecated.");
     }
     loadProperties("application.properties", source);
     if (loadProperties("ebean.properties", source)) {
-      Config.log.log(Level.WARNING,"Loading properties from ebean.properties is deprecated. Please migrate to use application.yaml or application.properties instead.");
+      Config.log.log(Level.WARNING, "Loading properties from ebean.properties is deprecated. Please migrate to use application.yaml or application.properties instead.");
     }
   }
 

--- a/src/test/java/io/avaje/config/InitialLoaderTest.java
+++ b/src/test/java/io/avaje/config/InitialLoaderTest.java
@@ -105,4 +105,19 @@ class InitialLoaderTest {
     loader.loadViaCommandLine(new String[]{"-p", "test-dummy2.yaml"});
     assertEquals(1, loader.size());
   }
+
+  @Test
+  void load_withSuppressTestResource() {
+    //application-test.yaml is loaded when suppressTestResource is not set to true
+    System.setProperty("suppressTestResource", "");
+    InitialLoader loader = new InitialLoader();
+    Properties properties = loader.load();
+    assertThat(properties.getProperty("myapp.activateFoo")).isEqualTo("true");
+
+    //application-test.yaml is not loaded when suppressTestResource is set to true
+    System.setProperty("suppressTestResource", "true");
+    InitialLoader loaderWithSuppressTestResource = new InitialLoader();
+    Properties propertiesWithoutTestResource = loaderWithSuppressTestResource.load();
+    assertThat(propertiesWithoutTestResource.getProperty("myapp.activateFoo")).isNull();
+  }
 }


### PR DESCRIPTION
With `System.setProperty("suppressTestResource", "true");`   then the test resources `application-test.yaml` and `application-test.properties` will not be loaded.

This is desired to support the case where we want to run a main method in the test classpath that effectively uses the "main configuration" and ignores the "test configuration".

This use case is kind of a Utility that lives in `src/test` and has access to test dependencies etc but where we don't wish it to use the test configuration (we want it to ignore `application-test.yaml` etc).
