### PR TITLE
[API CHANGE] Use @NonNullApi, get(key, null) no longer supported - use getOptional()  setProperty(key, null) no longer supported use clearProperty()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,12 @@
 
     <dependency>
       <groupId>io.avaje</groupId>
+      <artifactId>avaje-lang</artifactId>
+      <version>1.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
       <artifactId>avaje-applog</artifactId>
       <version>1.0</version>
     </dependency>

--- a/src/main/java/io/avaje/config/Config.java
+++ b/src/main/java/io/avaje/config/Config.java
@@ -1,5 +1,7 @@
 package io.avaje.config;
 
+import io.avaje.lang.NonNullApi;
+
 import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URL;
@@ -30,6 +32,7 @@ import java.util.function.LongConsumer;
  *
  * }</pre>
  */
+@NonNullApi
 public class Config {
 
   private static final Configuration data = CoreConfiguration.initialise();
@@ -404,6 +407,15 @@ public class Config {
    */
   public static void setProperty(String key, String value) {
     data.setProperty(key, value);
+  }
+
+  /**
+   * Clear the value for the given key.
+   *
+   * @param key The configuration key we want to clear
+   */
+  public static void clearProperty(String key) {
+    data.clearProperty(key);
   }
 
   /**

--- a/src/main/java/io/avaje/config/Configuration.java
+++ b/src/main/java/io/avaje/config/Configuration.java
@@ -1,5 +1,7 @@
 package io.avaje.config;
 
+import io.avaje.lang.NonNullApi;
+
 import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URL;
@@ -26,6 +28,7 @@ import java.util.function.LongConsumer;
  *
  * }</pre>
  */
+@NonNullApi
 public interface Configuration {
 
   /**
@@ -288,11 +291,16 @@ public interface Configuration {
   /**
    * Set a configuration value.
    * <p>
-   * This will fire an configuration callback listeners that are registered
-   * for this key.
-   * </p>
+   * This will fire configuration callback listeners that are registered for this key.
    */
   void setProperty(String key, String value);
+
+  /**
+   * Remove a configuration value for the given key.
+   * <p>
+   * This will fire configuration callback listeners that are registered for this key.
+   */
+  void clearProperty(String key);
 
   /**
    * Register a callback for a change to the given configuration key.

--- a/src/main/java/io/avaje/config/CoreListValue.java
+++ b/src/main/java/io/avaje/config/CoreListValue.java
@@ -15,7 +15,7 @@ final class CoreListValue implements Configuration.ListValue {
 
   @Override
   public List<String> of(String key) {
-    final String val = config.get(key, null);
+    final String val = config.value(key);
     if (val == null) {
       return Collections.emptyList();
     }
@@ -24,7 +24,7 @@ final class CoreListValue implements Configuration.ListValue {
 
   @Override
   public List<String> of(String key, String... defaultValues) {
-    final String val = config.get(key, null);
+    final String val = config.value(key);
     if (val == null) {
       return Arrays.asList(defaultValues);
     }
@@ -33,7 +33,7 @@ final class CoreListValue implements Configuration.ListValue {
 
   @Override
   public List<Integer> ofInt(String key) {
-    final String val = config.get(key, null);
+    final String val = config.value(key);
     if (val == null) {
       return Collections.emptyList();
     }
@@ -42,7 +42,7 @@ final class CoreListValue implements Configuration.ListValue {
 
   @Override
   public List<Integer> ofInt(String key, int... defaultValues) {
-    final String val = config.get(key, null);
+    final String val = config.value(key);
     if (val == null) {
       List<Integer> ints = new ArrayList<>(defaultValues.length);
       for (int defaultVal : defaultValues) {
@@ -55,7 +55,7 @@ final class CoreListValue implements Configuration.ListValue {
 
   @Override
   public List<Long> ofLong(String key) {
-    final String val = config.get(key, null);
+    final String val = config.value(key);
     if (val == null) {
       return Collections.emptyList();
     }
@@ -64,7 +64,7 @@ final class CoreListValue implements Configuration.ListValue {
 
   @Override
   public List<Long> ofLong(String key, long... defaultValues) {
-    final String val = config.get(key, null);
+    final String val = config.value(key);
     if (val == null) {
       List<Long> ints = new ArrayList<>(defaultValues.length);
       for (long defaultVal : defaultValues) {

--- a/src/main/java/io/avaje/config/CoreSetValue.java
+++ b/src/main/java/io/avaje/config/CoreSetValue.java
@@ -15,7 +15,7 @@ final class CoreSetValue implements Configuration.SetValue {
 
   @Override
   public Set<String> of(String key) {
-    final String val = config.get(key, null);
+    final String val = config.value(key);
     if (val == null) {
       return Collections.emptySet();
     }
@@ -24,7 +24,7 @@ final class CoreSetValue implements Configuration.SetValue {
 
   @Override
   public Set<String> of(String key, String... defaultValues) {
-    final String val = config.get(key, null);
+    final String val = config.value(key);
     if (val == null) {
       Set<String> values = new LinkedHashSet<>();
       Collections.addAll(values, defaultValues);
@@ -35,7 +35,7 @@ final class CoreSetValue implements Configuration.SetValue {
 
   @Override
   public Set<Integer> ofInt(String key) {
-    final String val = config.get(key, null);
+    final String val = config.value(key);
     if (val == null) {
       return Collections.emptySet();
     }
@@ -44,7 +44,7 @@ final class CoreSetValue implements Configuration.SetValue {
 
   @Override
   public Set<Integer> ofInt(String key, int... defaultValues) {
-    final String val = config.get(key, null);
+    final String val = config.value(key);
     if (val == null) {
       Set<Integer> ints = new LinkedHashSet<>();
       for (int defaultVal : defaultValues) {
@@ -57,7 +57,7 @@ final class CoreSetValue implements Configuration.SetValue {
 
   @Override
   public Set<Long> ofLong(String key) {
-    final String val = config.get(key, null);
+    final String val = config.value(key);
     if (val == null) {
       return Collections.emptySet();
     }
@@ -66,7 +66,7 @@ final class CoreSetValue implements Configuration.SetValue {
 
   @Override
   public Set<Long> ofLong(String key, long... defaultValues) {
-    final String val = config.get(key, null);
+    final String val = config.value(key);
     if (val == null) {
       Set<Long> ints = new LinkedHashSet<>();
       for (long defaultVal : defaultValues) {

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -2,6 +2,7 @@ module io.avaje.config {
 
   exports io.avaje.config;
 
+  requires transitive io.avaje.lang;
   requires transitive io.avaje.applog;
   requires static org.yaml.snakeyaml;
 

--- a/src/test/java/io/avaje/config/ConfigTest.java
+++ b/src/test/java/io/avaje/config/ConfigTest.java
@@ -22,7 +22,7 @@ class ConfigTest {
 
     // cached the initial value, still bar even when system property changed
     System.setProperty("MySystemProp0", "bazz");
-    assertThat(Config.get("MySystemProp0", null)).isEqualTo("bar");
+    assertThat(Config.get("MySystemProp0")).isEqualTo("bar");
 
     // mutate via Config.setProperty()
     Config.setProperty("MySystemProp0", "caz");
@@ -34,10 +34,10 @@ class ConfigTest {
 
   @Test
   void fallbackToSystemProperty_cacheInitialNullValue() {
-    assertThat(Config.get("MySystemProp", null)).isNull();
+    assertThat(Config.getOptional("MySystemProp")).isEmpty();
     System.setProperty("MySystemProp", "hello");
     // cached the initial null so still null
-    assertThat(Config.get("MySystemProp", null)).isNull();
+    assertThat(Config.getOptional("MySystemProp")).isEmpty();
   }
 
   @Test
@@ -45,13 +45,13 @@ class ConfigTest {
     assertThat(Config.get("MySystemProp2", "foo")).isEqualTo("foo");
     System.setProperty("MySystemProp2", "notFoo");
     // cached the initial value foo so still foo
-    assertThat(Config.get("MySystemProp2", null)).isEqualTo("foo");
-    Config.setProperty("MySystemProp2", null);
+    assertThat(Config.get("MySystemProp2")).isEqualTo("foo");
+    Config.clearProperty("MySystemProp2");
   }
 
   @Test
   void setProperty() {
-    assertThat(Config.get("MySystemProp3", null)).isNull();
+    assertThat(Config.getOptional("MySystemProp3")).isEmpty();
     Config.setProperty("MySystemProp3", "hello2");
     assertThat(Config.get("MySystemProp3")).isEqualTo("hello2");
   }
@@ -112,12 +112,12 @@ class ConfigTest {
   @Test
   public void get_default() {
     assertThat(Config.get("myapp.doesNotExist2", "MyDefault")).isEqualTo("MyDefault");
-    assertThat(Config.get("myapp.doesNotExist2", null)).isEqualTo("MyDefault");
+    assertThat(Config.get("myapp.doesNotExist2")).isEqualTo("MyDefault");
   }
 
   @Test
   void get_default_repeated_expect_returnDefaultValue() {
-    assertThat(Config.get("myapp.doesNotExist3", null)).isNull();
+    assertThat(Config.getOptional("myapp.doesNotExist3")).isEmpty();
     assertThat(Config.get("myapp.doesNotExist3", "other")).isEqualTo("other");
     assertThat(Config.get("myapp.doesNotExist3", "foo")).isEqualTo("foo");
     assertThat(Config.get("myapp.doesNotExist3", "junk")).isEqualTo("junk");
@@ -131,13 +131,13 @@ class ConfigTest {
 
   @Test
   void getBool_required_missing() {
-    Config.setProperty("myapp.doesNotExist", null);
+    Config.clearProperty("myapp.doesNotExist");
     assertThrows(IllegalStateException.class, () -> Config.getBool("myapp.doesNotExist"));
   }
 
   @Test
   void enabled_required_missing() {
-    Config.setProperty("myapp.doesNotExist", null);
+    Config.clearProperty("myapp.doesNotExist");
     assertThrows(IllegalStateException.class, () -> Config.enabled("myapp.doesNotExist"));
   }
 
@@ -171,7 +171,7 @@ class ConfigTest {
     // can dynamically change
     Config.setProperty("myapp.en.doesNotExist", "true");
     assertThat(Config.enabled("myapp.en.doesNotExist", true)).isTrue();
-    Config.setProperty("myapp.en.doesNotExist", null);
+    Config.clearProperty("myapp.en.doesNotExist");
   }
 
   @Test
@@ -222,7 +222,7 @@ class ConfigTest {
   @Test
   void getDecimal_default() {
     assertThat(Config.getDecimal("myTestDecimal.doesNotExist", "10.4")).isEqualByComparingTo("10.4");
-    Config.setProperty("myTestDecimal.doesNotExist", null);
+    Config.clearProperty("myTestDecimal.doesNotExist");
   }
 
   @Test
@@ -230,7 +230,7 @@ class ConfigTest {
     Config.setProperty("myTestDecimal", "14.3");
     assertThat(Config.getDecimal("myTestDecimal")).isEqualByComparingTo("14.3");
     assertThat(Config.getDecimal("myTestDecimal", "10.4")).isEqualByComparingTo("14.3");
-    Config.setProperty("myTestDecimal", null);
+    Config.clearProperty("myTestDecimal");
   }
 
   @Test
@@ -238,7 +238,7 @@ class ConfigTest {
     Config.setProperty("myConfigUrl", "http://bana");
     assertThat(Config.getURL("myConfigUrl")).isEqualTo(new URL("http://bana"));
     assertThat(Config.getURL("myConfigUrl", "http://two")).isEqualTo(new URL("http://bana"));
-    Config.setProperty("myConfigUrl", null);
+    Config.clearProperty("myConfigUrl");
   }
 
   @Test
@@ -246,7 +246,7 @@ class ConfigTest {
     Config.setProperty("myConfigUrl", "http://bana");
     assertThat(Config.getURI("myConfigUrl")).isEqualTo(URI.create("http://bana"));
     assertThat(Config.getURI("myConfigUrl", "http://two")).isEqualTo(URI.create("http://bana"));
-    Config.setProperty("myConfigUrl", null);
+    Config.clearProperty("myConfigUrl");
   }
 
   @Test
@@ -254,7 +254,7 @@ class ConfigTest {
     Config.setProperty("myConfigDuration", "PT10H");
     assertThat(Config.getDuration("myConfigDuration")).isEqualTo(Duration.parse("PT10H"));
     assertThat(Config.getDuration("myConfigDuration", "PT10H")).isEqualTo(Duration.parse("PT10H"));
-    Config.setProperty("myConfigDuration", null);
+    Config.clearProperty("myConfigDuration");
   }
 
   @Test
@@ -265,7 +265,7 @@ class ConfigTest {
   @Test
   void getEnum_default() {
     assertThat(Config.getEnum(MyTestEnum.class, "myTestEnum.doesNotExist2", MyTestEnum.C)).isEqualTo(MyTestEnum.C);
-    Config.setProperty("myTestEnum.doesNotExist2", null);
+    Config.clearProperty("myTestEnum.doesNotExist2");
   }
 
   @Test
@@ -273,7 +273,7 @@ class ConfigTest {
     Config.setProperty("myTestEnum", "B");
     assertThat(Config.getEnum(MyTestEnum.class, "myTestEnum")).isEqualTo(MyTestEnum.B);
     assertThat(Config.getEnum(MyTestEnum.class, "myTestEnum", MyTestEnum.C)).isEqualTo(MyTestEnum.B);
-    Config.setProperty("myTestEnum", null);
+    Config.clearProperty("myTestEnum");
   }
 
   enum MyTestEnum {

--- a/src/test/java/io/avaje/config/CoreConfigurationTest.java
+++ b/src/test/java/io/avaje/config/CoreConfigurationTest.java
@@ -147,7 +147,7 @@ class CoreConfigurationTest {
   @Test
   void getDecimal_default() {
     assertThat(data.getDecimal("myTestDecimal.doesNotExist", "10.4")).isEqualByComparingTo("10.4");
-    data.setProperty("myTestDecimal.doesNotExist", null);
+    data.clearProperty("myTestDecimal.doesNotExist");
   }
 
   @Test
@@ -155,7 +155,7 @@ class CoreConfigurationTest {
     data.setProperty("myTestDecimal", "14.3");
     assertThat(data.getDecimal("myTestDecimal")).isEqualByComparingTo("14.3");
     assertThat(data.getDecimal("myTestDecimal", "10.4")).isEqualByComparingTo("14.3");
-    data.setProperty("myTestDecimal", null);
+    data.clearProperty("myTestDecimal");
   }
 
   @Test
@@ -177,7 +177,7 @@ class CoreConfigurationTest {
   @Test
   void getURL_default() throws MalformedURLException {
     assertThat(data.getURL("myUrl.doesNotExist", "http://foo")).isEqualTo(new URL("http://foo"));
-    data.setProperty("myUrl.doesNotExist", null);
+    data.clearProperty("myUrl.doesNotExist");
   }
 
   @Test
@@ -185,7 +185,7 @@ class CoreConfigurationTest {
     data.setProperty("myUrl", "http://bar");
     assertThat(data.getURL("myUrl")).isEqualTo(new URL("http://bar"));
     assertThat(data.getURL("myUrl", "http://baz")).isEqualTo(new URL("http://bar"));
-    data.setProperty("myUrl", null);
+    data.clearProperty("myUrl");
   }
 
   @Test
@@ -258,7 +258,7 @@ class CoreConfigurationTest {
     data.setProperty("modify", "change");
     assertThat(count.get()).isEqualTo(1);
 
-    data.setProperty("modify", null);
+    data.clearProperty("modify");
     assertThat(count.get()).isEqualTo(2);
     assertThat(sb.toString()).isEqualTo("change,null,");
 
@@ -269,10 +269,10 @@ class CoreConfigurationTest {
 
   @Test
   void setProperty_withEval() {
-    assertThat(data.get("ThisIsNotSet", null)).isNull();
+    assertThat(data.getOptional("ThisIsNotSet")).isEmpty();
     data.setProperty("ThisIsNotSet", "A|${user.home}|B");
     String expected = "A|" + System.getProperty("user.home") + "|B";
-    assertThat(data.get("ThisIsNotSet", null)).isEqualTo(expected);
+    assertThat(data.get("ThisIsNotSet")).isEqualTo(expected);
   }
 
   @Test

--- a/src/test/java/io/avaje/config/FileWatchTest.java
+++ b/src/test/java/io/avaje/config/FileWatchTest.java
@@ -41,7 +41,7 @@ class FileWatchTest {
     final FileWatch watch = new FileWatch(config, files, new YamlLoaderSnake());
 
     assertThat(config.size()).isEqualTo(2);
-    assertThat(config.get("one", null)).isNull();
+    assertThat(config.getOptional("one")).isEmpty();
 
     touchFiles(files);
     // check after touch means files loaded
@@ -50,7 +50,7 @@ class FileWatchTest {
     // properties loaded as expected
     final int size0 = config.size();
     assertThat(size0).isGreaterThan(2);
-    assertThat(config.get("one", null)).isEqualTo("a");
+    assertThat(config.get("one")).isEqualTo("a");
     assertThat(config.getInt("my.size", 42)).isEqualTo(17);
     assertThat(config.getBool("c.active", false)).isTrue();
   }
@@ -81,7 +81,7 @@ class FileWatchTest {
 
     // properties loaded as expected
     assertThat(config.size()).isGreaterThan(2);
-    assertThat(config.get("one", null)).isEqualTo("a");
+    assertThat(config.get("one")).isEqualTo("a");
     assertThat(config.getInt("my.size", 42)).isEqualTo(17);
     assertThat(config.getBool("c.active", false)).isTrue();
   }
@@ -97,19 +97,19 @@ class FileWatchTest {
     if (isGithubActions()) {
       File aFile = files.get(0);
       log.info("file change detection in GithubActions via change in length from {}", aFile.length());
-      assertThat(config.get("one", null)).isNull();
+      assertThat(config.getOptional("one")).isEmpty();
 
       writeContent("one=NotAReally");
       sleep(20);
       log.info("file length now {}", aFile.length());
       watch.check();
-      assertThat(config.get("one", null)).isEqualTo("NotAReally");
+      assertThat(config.get("one")).isEqualTo("NotAReally");
 
       writeContent("one=a");
       sleep(20);
       log.info("file length now {}", aFile.length());
       watch.check();
-      assertThat(config.get("one", null)).isEqualTo("a");
+      assertThat(config.get("one")).isEqualTo("a");
       return;
     }
 
@@ -119,7 +119,7 @@ class FileWatchTest {
     // properties loaded as expected
     final int size0 = config.size();
     assertThat(size0).isGreaterThan(2);
-    assertThat(config.get("one", null)).isEqualTo("a");
+    assertThat(config.get("one")).isEqualTo("a");
 
     writeContent("one=NotA");
     sleep(20);
@@ -127,11 +127,11 @@ class FileWatchTest {
     watch.check();
     assertThat(watch.changed()).isFalse();
 
-    assertThat(config.get("one", null)).isEqualTo("NotA");
+    assertThat(config.get("one")).isEqualTo("NotA");
     writeContent("one=a");
     sleep(20);
     watch.check();
-    assertThat(config.get("one", null)).isEqualTo("a");
+    assertThat(config.get("one")).isEqualTo("a");
   }
 
   private void writeContent(String content) throws IOException {

--- a/src/test/java/org/example/MyExternalLoader.java
+++ b/src/test/java/org/example/MyExternalLoader.java
@@ -10,7 +10,7 @@ public class MyExternalLoader implements ConfigurationSource {
 
     // we can read properties that have been already
     // loaded from files/resources if desired
-    configuration.get("myExternalLoader.location", null);
+    configuration.getOptional("myExternalLoader.location");
 
     // add set properties (kind of the point)
     configuration.setProperty("myExternalLoader", "wasExecuted");


### PR DESCRIPTION
Breaking changes:
- get(key, null) is no longer supported, must use getOptional() instead
- setProperty(key, null) is no longer supported, must use clearProperty(key)