### PR TITLE
Refactor internals to add CoreEntry and Map

### DIFF
--- a/avaje-config/src/main/java/io/avaje/config/Constants.java
+++ b/avaje-config/src/main/java/io/avaje/config/Constants.java
@@ -1,0 +1,11 @@
+package io.avaje.config;
+
+final class Constants {
+
+  private Constants() {}
+
+  public static final String USER_PROVIDED = "SetProperty Method";
+  public static final String USER_PROVIDED_DEFAULT = "Default Value";
+  public static final String SYSTEM_PROPS = "System Properties";
+  public static final String ENV_VARIABLES = "Enviroment Variables";
+}

--- a/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
@@ -33,11 +33,11 @@ final class CoreConfiguration implements Configuration {
   private Timer timer;
   private final String pathPrefix;
 
-  CoreConfiguration(EventLog log, Properties source) {
-    this(log, CoreEntry.newMap(source), "");
+  CoreConfiguration(EventLog log, CoreEntry.CoreMap source) {
+    this(log, source, "");
   }
 
-  CoreConfiguration(EventLog log, CoreEntry.Map source, String prefix) {
+  CoreConfiguration(EventLog log, CoreEntry.CoreMap source, String prefix) {
     this.log = log;
     this.properties = new ModifyAwareProperties(this, source);
     this.listValue = new CoreListValue(this);
@@ -353,11 +353,11 @@ final class CoreConfiguration implements Configuration {
 
   private static class ModifyAwareProperties {
 
-    private final CoreEntry.Map entries;
+    private final CoreEntry.CoreMap entries;
     private final Configuration.ExpressionEval eval;
     private final CoreConfiguration config;
 
-    ModifyAwareProperties(CoreConfiguration config, CoreEntry.Map entries) {
+    ModifyAwareProperties(CoreConfiguration config, CoreEntry.CoreMap entries) {
       this.config = config;
       this.entries = entries;
       this.eval = new CoreExpressionEval(entries);
@@ -377,7 +377,7 @@ final class CoreConfiguration implements Configuration {
      */
     void setValue(String key, String newValue) {
       newValue = eval.eval(newValue);
-      final CoreEntry oldEntry = entries.put(key, newValue);
+      final CoreEntry oldEntry = entries.put(key, newValue, Constants.USER_PROVIDED);
       if (oldEntry == null || !Objects.equals(newValue, oldEntry.value())) {
         config.fireOnChange(key, newValue);
       }
@@ -415,10 +415,10 @@ final class CoreConfiguration implements Configuration {
       if (value == null) {
         // defining property at runtime with System property backing
         String systemValue = System.getProperty(key);
-        value = systemValue != null ? CoreEntry.of(systemValue) : defaultValue != null ? CoreEntry.of(defaultValue) : CoreEntry.NULL_ENTRY;
+        value = systemValue != null ? CoreEntry.of(systemValue, "SystemProperty") : defaultValue != null ? CoreEntry.of(defaultValue, Constants.USER_PROVIDED_DEFAULT) : CoreEntry.NULL_ENTRY;
         entries.put(key, value);
       } else if (value.isNull() && defaultValue != null) {
-        value = CoreEntry.of(defaultValue);
+        value = CoreEntry.of(defaultValue, Constants.USER_PROVIDED_DEFAULT);
         entries.put(key, value);
       }
       return value;

--- a/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
@@ -425,11 +425,21 @@ final class CoreConfiguration implements Configuration {
     }
 
     void loadIntoSystemProperties(Set<String> excludedSet) {
-      entries.loadIntoSystemProperties(excludedSet);
+      entries.forEach((key, entry) -> {
+        if (!excludedSet.contains(key) && !entry.isNull()) {
+          System.setProperty(key, entry.value());
+        }
+      });
     }
 
     Properties asProperties() {
-      return entries.asProperties();
+      Properties props = new Properties();
+      entries.forEach((key, entry) -> {
+        if (!entry.isNull()) {
+          props.setProperty(key, entry.value());
+        }
+      });
+      return props;
     }
   }
 

--- a/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
@@ -148,15 +148,15 @@ final class CoreConfiguration implements Configuration {
   public Configuration forPath(String pathPrefix) {
     final var dotPrefix = pathPrefix + '.';
     final var dotLength = dotPrefix.length();
-    final var newProps = CoreEntry.newMap();
+    final var newEntryMap = CoreEntry.newMap();
     properties.entries.forEach((key, entry) -> {
       if (key.startsWith(dotPrefix)) {
-        newProps.put(key.substring(dotLength), entry);
+        newEntryMap.put(key.substring(dotLength), entry);
       } else if (key.equals(pathPrefix)) {
-        newProps.put("", entry);
+        newEntryMap.put("", entry);
       }
     });
-    return new CoreConfiguration(log, newProps, dotPrefix);
+    return new CoreConfiguration(log, newEntryMap, dotPrefix);
   }
 
   @Override

--- a/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
@@ -34,10 +34,10 @@ final class CoreConfiguration implements Configuration {
   private final String pathPrefix;
 
   CoreConfiguration(EventLog log, Properties source) {
-    this(log, source, "");
+    this(log, CoreEntry.newMap(source), "");
   }
 
-  CoreConfiguration(EventLog log, Properties source, String prefix) {
+  CoreConfiguration(EventLog log, CoreEntry.Map source, String prefix) {
     this.log = log;
     this.properties = new ModifyAwareProperties(this, source);
     this.listValue = new CoreListValue(this);
@@ -148,15 +148,14 @@ final class CoreConfiguration implements Configuration {
   public Configuration forPath(String pathPrefix) {
     final var dotPrefix = pathPrefix + '.';
     final var dotLength = dotPrefix.length();
-    final var newProps = new Properties();
-    for (Map.Entry<String, String> entry : properties.properties.entrySet()) {
-      final var key = entry.getKey();
+    final var newProps = CoreEntry.newMap();
+    properties.entries.forEach((key, entry) -> {
       if (key.startsWith(dotPrefix)) {
-        newProps.put(key.substring(dotLength), entry.getValue());
+        newProps.put(key.substring(dotLength), entry);
       } else if (key.equals(pathPrefix)) {
-        newProps.put("", entry.getValue());
+        newProps.put("", entry);
       }
-    }
+    });
     return new CoreConfiguration(log, newProps, dotPrefix);
   }
 
@@ -172,7 +171,7 @@ final class CoreConfiguration implements Configuration {
 
   @Nullable
   String value(String key) {
-    return properties.value(key);
+    return properties.entry(key).value();
   }
 
   private String required(String key) {
@@ -192,7 +191,7 @@ final class CoreConfiguration implements Configuration {
   public String get(String key, String defaultValue) {
     requireNonNull(key, "key is required");
     requireNonNull(defaultValue, "defaultValue is required, use getOptional() instead");
-    return properties.value(key, defaultValue);
+    return properties.entry(key, defaultValue).value();
   }
 
   @Override
@@ -354,36 +353,23 @@ final class CoreConfiguration implements Configuration {
 
   private static class ModifyAwareProperties {
 
-    /**
-     * Null value placeholder in properties ConcurrentHashMap.
-     */
-    private static final String NULL_PLACEHOLDER = "NULL";
-
-    private final Map<String, String> properties = new ConcurrentHashMap<>();
-    private final Map<String, Boolean> propertiesBoolCache = new ConcurrentHashMap<>();
-    private final Configuration.ExpressionEval eval = new CoreExpressionEval(properties);
+    private final CoreEntry.Map entries;
+    private final Configuration.ExpressionEval eval;
     private final CoreConfiguration config;
 
-    ModifyAwareProperties(CoreConfiguration config, Properties source) {
+    ModifyAwareProperties(CoreConfiguration config, CoreEntry.Map entries) {
       this.config = config;
-      loadAll(source);
-    }
-
-    private void loadAll(Properties source) {
-      for (Map.Entry<Object, Object> entry : source.entrySet()) {
-        if (entry.getValue() != null) {
-          properties.put(entry.getKey().toString(), entry.getValue().toString());
-        }
-      }
+      this.entries = entries;
+      this.eval = new CoreExpressionEval(entries);
     }
 
     @Override
     public String toString() {
-      return properties.toString();
+      return entries.toString();
     }
 
     int size() {
-      return properties.size();
+      return entries.size();
     }
 
     /**
@@ -391,17 +377,15 @@ final class CoreConfiguration implements Configuration {
      */
     void setValue(String key, String newValue) {
       newValue = eval.eval(newValue);
-      Object oldValue = properties.put(key, newValue);
-      if (!Objects.equals(newValue, oldValue)) {
-        propertiesBoolCache.remove(key);
+      final CoreEntry oldEntry = entries.put(key, newValue);
+      if (oldEntry == null || !Objects.equals(newValue, oldEntry.value())) {
         config.fireOnChange(key, newValue);
       }
     }
 
     void clearValue(String key) {
-      Object oldValue = properties.remove(key);
+      final CoreEntry oldValue = entries.remove(key);
       if (oldValue != null) {
-        propertiesBoolCache.remove(key);
         config.fireOnChange(key, null);
       }
     }
@@ -412,62 +396,40 @@ final class CoreConfiguration implements Configuration {
      * with very high concurrent use.
      */
     boolean getBool(String key, boolean defaultValue) {
-      final Boolean cachedValue = propertiesBoolCache.get(key);
-      if (cachedValue != null) {
-        return cachedValue;
-      }
-      // populate our specialised boolean cache to minimise costs on heavy use
-      final String rawValue = value(key);
-      boolean value = (rawValue == null) ? defaultValue : Boolean.parseBoolean(rawValue);
-      propertiesBoolCache.put(key, value);
-      return value;
+      return entry(key, String.valueOf(defaultValue)).boolValue();
     }
 
-    @Nullable
-    String value(String key) {
-      return _value(key, null);
+    CoreEntry entry(String key) {
+      return _entry(key, null);
     }
 
-    String value(String key, String defaultValue) {
-      return _value(key, defaultValue);
+    CoreEntry entry(String key, String defaultValue) {
+      return _entry(key, defaultValue);
     }
 
     /**
      * Get property with caching taking into account defaultValue and "null".
      */
-    @Nullable
-    private String _value(String key, @Nullable String defaultValue) {
-      String value = properties.get(key);
+    private CoreEntry _entry(String key, @Nullable String defaultValue) {
+      CoreEntry value = entries.get(key);
       if (value == null) {
         // defining property at runtime with System property backing
-        value = System.getProperty(key);
-        if (value == null) {
-          value = (defaultValue == null) ? NULL_PLACEHOLDER : defaultValue;
-        }
-        // cache in concurrent map to provide higher concurrent use
-        properties.put(key, value);
+        String systemValue = System.getProperty(key);
+        value = systemValue != null ? CoreEntry.of(systemValue) : defaultValue != null ? CoreEntry.of(defaultValue) : CoreEntry.NULL_ENTRY;
+        entries.put(key, value);
+      } else if (value.isNull() && defaultValue != null) {
+        value = CoreEntry.of(defaultValue);
+        entries.put(key, value);
       }
-      return value != NULL_PLACEHOLDER ? value : defaultValue;
+      return value;
     }
 
     void loadIntoSystemProperties(Set<String> excludedSet) {
-      for (Map.Entry<String, String> entry : properties.entrySet()) {
-        final String value = entry.getValue();
-        if (!excludedSet.contains(entry.getKey()) && (value != NULL_PLACEHOLDER)) {
-          System.setProperty(entry.getKey(), value);
-        }
-      }
+      entries.loadIntoSystemProperties(excludedSet);
     }
 
     Properties asProperties() {
-      Properties props = new Properties();
-      for (Map.Entry<String, String> entry : properties.entrySet()) {
-        final String value = entry.getValue();
-        if (value != NULL_PLACEHOLDER) {
-          props.setProperty(entry.getKey(), value);
-        }
-      }
-      return props;
+      return entries.asProperties();
     }
   }
 

--- a/avaje-config/src/main/java/io/avaje/config/CoreEntry.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreEntry.java
@@ -118,24 +118,6 @@ final class CoreEntry {
       return entry == null ? null : entry.value();
     }
 
-    Properties asProperties() {
-      Properties props = new Properties();
-      map.forEach((key, entry) -> {
-        if (!entry.isNull()) {
-          props.setProperty(key, entry.value());
-        }
-      });
-      return props;
-    }
-
-    void loadIntoSystemProperties(Set<String> excludedSet) {
-      map.forEach((key, entry) -> {
-        if (!excludedSet.contains(key) && !entry.isNull()) {
-          System.setProperty(key, entry.value());
-        }
-      });
-    }
-
     void forEach(BiConsumer<String, CoreEntry> consumer) {
       map.forEach(consumer);
     }

--- a/avaje-config/src/main/java/io/avaje/config/CoreEntry.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreEntry.java
@@ -1,0 +1,143 @@
+package io.avaje.config;
+
+import io.avaje.lang.NonNullApi;
+import io.avaje.lang.Nullable;
+
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Configuration entry.
+ */
+@NonNullApi
+final class CoreEntry {
+
+  /**
+   * Entry used to represent no entry / null.
+   */
+  static final CoreEntry NULL_ENTRY = new CoreEntry();
+
+  private final String value;
+  private final boolean boolValue;
+
+  /**
+   * Return a new empty map for entries.
+   */
+  static Map newMap() {
+    return new CoreEntry.Map();
+  }
+
+  /**
+   * Return a new map populated from the given Properties.
+   */
+  static Map newMap(Properties source) {
+    return new CoreEntry.Map(source);
+  }
+
+  /**
+   * Return an entry for the given value.
+   */
+  static CoreEntry of(@Nullable String val) {
+    return val == null ? NULL_ENTRY : new CoreEntry(val);
+  }
+
+  /**
+   * Construct for our special NULL entry.
+   */
+  private CoreEntry() {
+    this.value = null;
+    this.boolValue = false;
+  }
+
+  private CoreEntry(String value) {
+    requireNonNull(value);
+    this.value = value;
+    this.boolValue = Boolean.parseBoolean(value);
+  }
+
+  String value() {
+    return value;
+  }
+
+  boolean boolValue() {
+    return boolValue;
+  }
+
+  boolean isNull() {
+    return value == null;
+  }
+
+  /**
+   * A map like container of CoreEntry entries.
+   */
+  static class Map {
+
+    private final java.util.Map<String, CoreEntry> map = new ConcurrentHashMap<>();
+
+    Map() {
+    }
+
+    Map(Properties source) {
+      source.forEach((key, value) -> {
+        if (value != null) {
+          map.put(key.toString(), CoreEntry.of(value.toString()));
+        }
+      });
+    }
+
+    int size() {
+      return map.size();
+    }
+
+    @Nullable
+    CoreEntry get(String key) {
+      return map.get(key);
+    }
+
+    void put(String key, CoreEntry value) {
+      map.put(key, value);
+    }
+
+    @Nullable
+    CoreEntry put(String key, String value) {
+      return map.put(key, CoreEntry.of(value));
+    }
+
+    @Nullable
+    CoreEntry remove(String key) {
+      return map.remove(key);
+    }
+
+    @Nullable
+    String raw(String key) {
+      final CoreEntry entry = map.get(key);
+      return entry == null ? null : entry.value();
+    }
+
+    Properties asProperties() {
+      Properties props = new Properties();
+      map.forEach((key, entry) -> {
+        if (!entry.isNull()) {
+          props.setProperty(key, entry.value());
+        }
+      });
+      return props;
+    }
+
+    void loadIntoSystemProperties(Set<String> excludedSet) {
+      map.forEach((key, entry) -> {
+        if (!excludedSet.contains(key) && !entry.isNull()) {
+          System.setProperty(key, entry.value());
+        }
+      });
+    }
+
+    void forEach(BiConsumer<String, CoreEntry> consumer) {
+      map.forEach(consumer);
+    }
+  }
+}

--- a/avaje-config/src/main/java/io/avaje/config/CoreExpressionEval.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreExpressionEval.java
@@ -1,6 +1,5 @@
 package io.avaje.config;
 
-import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -20,13 +19,13 @@ final class CoreExpressionEval implements Configuration.ExpressionEval {
    */
   private static final String END = "}";
 
-  private Map<String, String> sourceMap;
+  private CoreEntry.Map sourceMap;
   private Properties sourceProperties;
 
   /**
    * Create with source map that can use used to eval expressions.
    */
-  CoreExpressionEval(Map<String, String> sourceMap) {
+  CoreExpressionEval(CoreEntry.Map sourceMap) {
     this.sourceMap = sourceMap;
   }
 
@@ -68,7 +67,7 @@ final class CoreExpressionEval implements Configuration.ExpressionEval {
 
   private String localLookup(String exp) {
     if (sourceMap != null) {
-      return sourceMap.get(exp);
+      return sourceMap.raw(exp);
     } else if (sourceProperties != null) {
       return sourceProperties.getProperty(exp);
     }

--- a/avaje-config/src/main/java/io/avaje/config/CoreExpressionEval.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreExpressionEval.java
@@ -19,13 +19,13 @@ final class CoreExpressionEval implements Configuration.ExpressionEval {
    */
   private static final String END = "}";
 
-  private CoreEntry.Map sourceMap;
+  private CoreEntry.CoreMap sourceMap;
   private Properties sourceProperties;
 
   /**
    * Create with source map that can use used to eval expressions.
    */
-  CoreExpressionEval(CoreEntry.Map sourceMap) {
+  CoreExpressionEval(CoreEntry.CoreMap sourceMap) {
     this.sourceMap = sourceMap;
   }
 

--- a/avaje-config/src/main/java/io/avaje/config/InitialLoadContext.java
+++ b/avaje-config/src/main/java/io/avaje/config/InitialLoadContext.java
@@ -7,6 +7,8 @@ import java.io.InputStream;
 import java.lang.System.Logger.Level;
 import java.util.*;
 
+import io.avaje.config.CoreEntry.CoreMap;
+
 /**
  * Manages the underlying map of properties we are gathering.
  */
@@ -14,9 +16,9 @@ final class InitialLoadContext {
 
   private final EventLog log;
   /**
-   * Map we are loading the properties into.
+   * CoreMap we are loading the properties into.
    */
-  private final CoreEntry.Map map = CoreEntry.newMap();
+  private final CoreEntry.CoreMap map = CoreEntry.newMap();
 
   /**
    * Names of resources/files that were loaded.
@@ -58,7 +60,7 @@ final class InitialLoadContext {
 
   private void initSystemProperty(String envValue, String key) {
     if (envValue != null && System.getProperty(key) == null) {
-      map.put(key, envValue);
+      map.put(key, envValue, Constants.ENV_VARIABLES);
     }
   }
 
@@ -109,21 +111,21 @@ final class InitialLoadContext {
   /**
    * Add a property entry.
    */
-  void put(String key, String val) {
+  void put(String key, String val, String source) {
     if (val != null) {
       val = val.trim();
     }
-    map.put(key, val);
+    map.put(key, val, source);
   }
 
   /**
    * Evaluate all the expressions and return as a Properties object.
    */
-  Properties evalAll() {
+  CoreMap evalAll() {
     log.log(Level.TRACE, "load from {0}", loadedResources);
-    Properties properties = new Properties();
-    map.forEach((key, entry) -> properties.setProperty(key, exprEval.eval(entry.value())));
-    return properties;
+    var core = CoreEntry.newMap();
+    map.forEach((key, entry) -> core.put(key, exprEval.eval(entry.value()), entry.source()));
+    return core;
   }
 
   /**

--- a/avaje-config/src/main/java/io/avaje/config/InitialLoadContext.java
+++ b/avaje-config/src/main/java/io/avaje/config/InitialLoadContext.java
@@ -5,13 +5,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.lang.System.Logger.Level;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Manages the underlying map of properties we are gathering.
@@ -22,7 +16,7 @@ final class InitialLoadContext {
   /**
    * Map we are loading the properties into.
    */
-  private final Map<String, String> map = new LinkedHashMap<>();
+  private final CoreEntry.Map map = CoreEntry.newMap();
 
   /**
    * Names of resources/files that were loaded.
@@ -128,10 +122,7 @@ final class InitialLoadContext {
   Properties evalAll() {
     log.log(Level.TRACE, "load from {0}", loadedResources);
     Properties properties = new Properties();
-    for (Map.Entry<String, String> entry : map.entrySet()) {
-      String key = entry.getKey();
-      properties.setProperty(key, exprEval.eval(entry.getValue()));
-    }
+    map.forEach((key, entry) -> properties.setProperty(key, exprEval.eval(entry.value())));
     return properties;
   }
 
@@ -139,11 +130,11 @@ final class InitialLoadContext {
    * Read the special properties that can point to an external properties source.
    */
   String indirectLocation() {
-    String indirectLocation = map.get("load.properties");
+    CoreEntry indirectLocation = map.get("load.properties");
     if (indirectLocation == null) {
       indirectLocation = map.get("load.properties.override");
     }
-    return indirectLocation;
+    return indirectLocation == null ? null : indirectLocation.value();
   }
 
   /**
@@ -154,7 +145,7 @@ final class InitialLoadContext {
   }
 
   String getAppName() {
-    final String appName = map.get("app.name");
-    return (appName != null) ? appName : System.getProperty("app.name");
+    final CoreEntry appName = map.get("app.name");
+    return (appName != null) ? appName.value() : System.getProperty("app.name");
   }
 }

--- a/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
+++ b/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
@@ -8,6 +8,8 @@ import java.util.Enumeration;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
+import io.avaje.config.CoreEntry.CoreMap;
+
 import static io.avaje.config.InitialLoader.Source.FILE;
 import static io.avaje.config.InitialLoader.Source.RESOURCE;
 
@@ -79,7 +81,7 @@ final class InitialLoader {
    *   - application-test.yaml
    * </pre>
    */
-  Properties load() {
+  CoreMap load() {
     loadEnvironmentVars();
     loadLocalFiles();
     return eval();
@@ -252,7 +254,7 @@ final class InitialLoader {
   /**
    * Evaluate all the configuration entries and return as properties.
    */
-  Properties eval() {
+  CoreMap eval() {
     return loadContext.evalAll();
   }
 
@@ -261,7 +263,7 @@ final class InitialLoader {
       try {
         try (InputStream is = resource(resourcePath, source)) {
           if (is != null) {
-            yamlLoader.load(is).forEach(loadContext::put);
+            yamlLoader.load(is).forEach((k, v) -> loadContext.put(k, v, (source == RESOURCE ? "resource:" : "file") + resourcePath));
             return true;
           }
         }
@@ -276,7 +278,7 @@ final class InitialLoader {
     try {
       try (InputStream is = resource(resourcePath, source)) {
         if (is != null) {
-          loadProperties(is);
+          loadProperties(is, (source == RESOURCE ? "resource:" : "file") + resourcePath);
           return true;
         }
       }
@@ -290,18 +292,18 @@ final class InitialLoader {
     return loadContext.resource(resourcePath, source);
   }
 
-  private void loadProperties(InputStream is) throws IOException {
+  private void loadProperties(InputStream is, String source) throws IOException {
     Properties properties = new Properties();
     properties.load(is);
-    put(properties);
+    put(properties, source);
   }
 
-  private void put(Properties properties) {
+  private void put(Properties properties, String source) {
     Enumeration<?> enumeration = properties.propertyNames();
     while (enumeration.hasMoreElements()) {
       String key = (String) enumeration.nextElement();
       String val = properties.getProperty(key);
-      loadContext.put(key, val);
+      loadContext.put(key, val, source);
     }
   }
 

--- a/avaje-config/src/test/java/io/avaje/config/ConfigTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/ConfigTest.java
@@ -74,7 +74,8 @@ class ConfigTest {
     assertThat(System.getProperty("myapp.bar.barRules")).isNull();
     assertThat(System.getProperty("myapp.bar.barDouble")).isEqualTo("33.3");
 
-    assertThat(properties).hasSize(8);
+    assertThat(properties).containsKeys("config.load.systemProperties", "config.watch.enabled", "myExternalLoader", "myapp.activateFoo", "myapp.bar.barDouble", "myapp.bar.barRules", "myapp.fooHome", "myapp.fooName", "system.excluded.properties");
+    assertThat(properties).hasSize(9);
   }
 
   @Test
@@ -119,8 +120,8 @@ class ConfigTest {
   void get_default_repeated_expect_returnDefaultValue() {
     assertThat(Config.getOptional("myapp.doesNotExist3")).isEmpty();
     assertThat(Config.get("myapp.doesNotExist3", "other")).isEqualTo("other");
-    assertThat(Config.get("myapp.doesNotExist3", "foo")).isEqualTo("foo");
-    assertThat(Config.get("myapp.doesNotExist3", "junk")).isEqualTo("junk");
+    assertThat(Config.get("myapp.doesNotExist3", "foo")).isEqualTo("other"); // No longer "foo" to be consistent with getBool treatment
+    assertThat(Config.get("myapp.doesNotExist3", "junk")).isEqualTo("other");
   }
 
   @Test

--- a/avaje-config/src/test/java/io/avaje/config/CoreExpressionEvalTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/CoreExpressionEvalTest.java
@@ -83,9 +83,9 @@ class CoreExpressionEvalTest {
 
   @Test
   void eval_withSourceMap() {
-    CoreEntry.Map source = CoreEntry.newMap();
-    source.put("one", "1");
-    source.put("two", "2");
+    CoreEntry.CoreMap source = CoreEntry.newMap();
+    source.put("one", "1","");
+    source.put("two", "2","");
     final CoreExpressionEval exprEval = new CoreExpressionEval(source);
 
     assertThat(exprEval.eval("foo${one}bar${two}baz${one}")).isEqualTo("foo1bar2baz1");

--- a/avaje-config/src/test/java/io/avaje/config/CoreExpressionEvalTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/CoreExpressionEvalTest.java
@@ -2,9 +2,6 @@ package io.avaje.config;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -86,7 +83,7 @@ class CoreExpressionEvalTest {
 
   @Test
   void eval_withSourceMap() {
-    Map<String, String> source = new HashMap<>();
+    CoreEntry.Map source = CoreEntry.newMap();
     source.put("one", "1");
     source.put("two", "2");
     final CoreExpressionEval exprEval = new CoreExpressionEval(source);
@@ -109,6 +106,6 @@ class CoreExpressionEvalTest {
   }
 
   private String eval(String key) {
-    return new CoreExpressionEval(Collections.emptyMap()).eval(key);
+    return new CoreExpressionEval(CoreEntry.newMap()).eval(key);
   }
 }

--- a/avaje-config/src/test/java/io/avaje/config/FileWatchTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/FileWatchTest.java
@@ -161,7 +161,7 @@ class FileWatchTest {
     final Properties properties = new Properties();
     properties.setProperty("config.watch.delay", "1");
     properties.setProperty("config.watch.period", "1");
-    return new CoreConfiguration(new DefaultEventLog(), properties);
+    return new CoreConfiguration(new DefaultEventLog(),  CoreEntry.newMap(properties, "newConfig"));
   }
 
   private List<File> files() {

--- a/avaje-config/src/test/java/io/avaje/config/InitialLoaderTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/InitialLoaderTest.java
@@ -22,17 +22,17 @@ class InitialLoaderTest {
     loader.loadProperties("test-properties/one.properties", RESOURCE);
     loader.loadYaml("test-properties/foo.yml", RESOURCE);
 
-    Properties properties = loader.eval();
+    var properties = loader.eval();
 
-    assertEquals("fromProperties", properties.getProperty("app.fromProperties"));
-    assertEquals("Two", properties.getProperty("app.two"));
+    assertEquals("fromProperties", properties.get("app.fromProperties").value());
+    assertEquals("Two", properties.get("app.two").value());
 
-    assertEquals("bart", properties.getProperty("eval.withDefault"));
-    assertEquals(userName, properties.getProperty("eval.name"));
-    assertEquals(userHome + "/after", properties.getProperty("eval.home"));
+    assertEquals("bart", properties.get("eval.withDefault").value());
+    assertEquals(userName, properties.get("eval.name").value());
+    assertEquals(userHome + "/after", properties.get("eval.home").value());
 
-    assertEquals("before|Beta|after", properties.getProperty("someOne"));
-    assertEquals("before|Two|after", properties.getProperty("someTwo"));
+    assertEquals("before|Beta|after", properties.get("someOne").value());
+    assertEquals("before|Two|after", properties.get("someTwo").value());
   }
 
   @Test
@@ -42,19 +42,19 @@ class InitialLoaderTest {
     loader.loadWithExtensionCheck("test-dummy.yml");
     loader.loadWithExtensionCheck("test-dummy2.yaml");
 
-    Properties properties = loader.eval();
-    assertThat(properties.getProperty("dummy.yaml.bar")).isEqualTo("baz");
-    assertThat(properties.getProperty("dummy.yml.foo")).isEqualTo("bar");
-    assertThat(properties.getProperty("dummy.properties.foo")).isEqualTo("bar");
+    var properties = loader.eval();
+    assertThat(properties.get("dummy.yaml.bar").value()).isEqualTo("baz");
+    assertThat(properties.get("dummy.yml.foo").value()).isEqualTo("bar");
+    assertThat(properties.get("dummy.properties.foo").value()).isEqualTo("bar");
   }
 
   @Test
   void loadYaml() {
     InitialLoader loader = new InitialLoader(new DefaultEventLog());
     loader.loadYaml("test-properties/foo.yml", RESOURCE);
-    Properties properties = loader.eval();
+    var properties = loader.eval();
 
-    assertThat(properties.getProperty("Some.Other.pass")).isEqualTo("someDefault");
+    assertThat(properties.get("Some.Other.pass").value()).isEqualTo("someDefault");
   }
 
   @Test
@@ -64,14 +64,15 @@ class InitialLoaderTest {
 
     InitialLoader loader = new InitialLoader(new DefaultEventLog());
     loader.loadProperties("test-properties/one.properties", RESOURCE);
-    Properties properties = loader.eval();
-
-    assertThat(properties.getProperty("hello")).isEqualTo("there");
-    assertThat(properties.getProperty("name")).isEqualTo("Rob");
-    assertThat(properties.getProperty("statusPageUrl")).isEqualTo("https://host1:9876/status");
-    assertThat(properties.getProperty("statusPageUrl2")).isEqualTo("https://aaa:9876/status2");
-    assertThat(properties.getProperty("statusPageUrl3")).isEqualTo("https://aaa:89/status3");
-    assertThat(properties.getProperty("statusPageUrl4")).isEqualTo("https://there:9876/name/Rob");
+    var properties = loader.eval();
+    
+    assertThat(properties.get("hello").source()).isEqualTo("resource:test-properties/one.properties");
+    assertThat(properties.get("hello").value()).isEqualTo("there");
+    assertThat(properties.get("name").value()).isEqualTo("Rob");
+    assertThat(properties.get("statusPageUrl").value()).isEqualTo("https://host1:9876/status");
+    assertThat(properties.get("statusPageUrl2").value()).isEqualTo("https://aaa:9876/status2");
+    assertThat(properties.get("statusPageUrl3").value()).isEqualTo("https://aaa:89/status3");
+    assertThat(properties.get("statusPageUrl4").value()).isEqualTo("https://there:9876/name/Rob");
   }
 
   @Test
@@ -112,14 +113,14 @@ class InitialLoaderTest {
     try {
       System.setProperty("suppressTestResource", "");
       InitialLoader loader = new InitialLoader(new DefaultEventLog());
-      Properties properties = loader.load();
-      assertThat(properties.getProperty("myapp.activateFoo")).isEqualTo("true");
+      var properties = loader.load();
+      assertThat(properties.get("myapp.activateFoo").value()).isEqualTo("true");
 
       //application-test.yaml is not loaded when suppressTestResource is set to true
       System.setProperty("suppressTestResource", "true");
       InitialLoader loaderWithSuppressTestResource = new InitialLoader(new DefaultEventLog());
-      Properties propertiesWithoutTestResource = loaderWithSuppressTestResource.load();
-      assertThat(propertiesWithoutTestResource.getProperty("myapp.activateFoo")).isNull();
+      var propertiesWithoutTestResource = loaderWithSuppressTestResource.load();
+      assertThat(propertiesWithoutTestResource.get("myapp.activateFoo")).isNull();
     } finally {
       System.clearProperty("suppressTestResource");
     }


### PR DESCRIPTION
- Configuration values are internally stored as CoreEntry
- For null entries now uses CoreEntry.NULL_ENTRY (Removes the NULL_PLACEHOLDER etc)
- Removes the specialised propertiesBoolCache, CoreEntry parses boolean value once
- Changes behavior such that `get(key, default)` stores an entry. This makes this consistent with how the boolean entries worked. Changes the test at: ConfigTest.get_default_repeated_expect_returnDefaultValue