### PR TITLE
Track Property Sources

### DIFF
--- a/avaje-config/src/main/java/io/avaje/config/Constants.java
+++ b/avaje-config/src/main/java/io/avaje/config/Constants.java
@@ -4,8 +4,8 @@ final class Constants {
 
   private Constants() {}
 
-  public static final String USER_PROVIDED = "Set Property Call";
-  public static final String USER_PROVIDED_DEFAULT = "Default Values";
+  public static final String USER_PROVIDED = "SetProperty Method";
+  public static final String USER_PROVIDED_DEFAULT = "Default Value";
   public static final String SYSTEM_PROPS = "System Properties";
   public static final String ENV_VARIABLES = "Enviroment Variables";
 }

--- a/avaje-config/src/main/java/io/avaje/config/Constants.java
+++ b/avaje-config/src/main/java/io/avaje/config/Constants.java
@@ -1,0 +1,11 @@
+package io.avaje.config;
+
+final class Constants {
+
+  private Constants() {}
+
+  public static final String USER_PROVIDED = "Set Property Call";
+  public static final String USER_PROVIDED_DEFAULT = "Default Values";
+  public static final String SYSTEM_PROPS = "System Properties";
+  public static final String ENV_VARIABLES = "Enviroment Variables";
+}

--- a/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
@@ -33,11 +33,11 @@ final class CoreConfiguration implements Configuration {
   private Timer timer;
   private final String pathPrefix;
 
-  CoreConfiguration(EventLog log, CoreEntry.CoreEntryMap source) {
+  CoreConfiguration(EventLog log, CoreEntry.CoreMap source) {
     this(log, source, "");
   }
 
-  CoreConfiguration(EventLog log, CoreEntry.CoreEntryMap source, String prefix) {
+  CoreConfiguration(EventLog log, CoreEntry.CoreMap source, String prefix) {
     this.log = log;
     this.properties = new ModifyAwareProperties(this, source);
     this.listValue = new CoreListValue(this);
@@ -353,11 +353,11 @@ final class CoreConfiguration implements Configuration {
 
   private static class ModifyAwareProperties {
 
-    private final CoreEntry.CoreEntryMap entries;
+    private final CoreEntry.CoreMap entries;
     private final Configuration.ExpressionEval eval;
     private final CoreConfiguration config;
 
-    ModifyAwareProperties(CoreConfiguration config, CoreEntry.CoreEntryMap entries) {
+    ModifyAwareProperties(CoreConfiguration config, CoreEntry.CoreMap entries) {
       this.config = config;
       this.entries = entries;
       this.eval = new CoreExpressionEval(entries);

--- a/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
@@ -33,11 +33,11 @@ final class CoreConfiguration implements Configuration {
   private Timer timer;
   private final String pathPrefix;
 
-  CoreConfiguration(EventLog log, Properties source) {
-    this(log, CoreEntry.newMap(source), "");
+  CoreConfiguration(EventLog log, CoreEntry.CoreEntryMap source) {
+    this(log, source, "");
   }
 
-  CoreConfiguration(EventLog log, CoreEntry.Map source, String prefix) {
+  CoreConfiguration(EventLog log, CoreEntry.CoreEntryMap source, String prefix) {
     this.log = log;
     this.properties = new ModifyAwareProperties(this, source);
     this.listValue = new CoreListValue(this);
@@ -353,11 +353,11 @@ final class CoreConfiguration implements Configuration {
 
   private static class ModifyAwareProperties {
 
-    private final CoreEntry.Map entries;
+    private final CoreEntry.CoreEntryMap entries;
     private final Configuration.ExpressionEval eval;
     private final CoreConfiguration config;
 
-    ModifyAwareProperties(CoreConfiguration config, CoreEntry.Map entries) {
+    ModifyAwareProperties(CoreConfiguration config, CoreEntry.CoreEntryMap entries) {
       this.config = config;
       this.entries = entries;
       this.eval = new CoreExpressionEval(entries);
@@ -377,7 +377,7 @@ final class CoreConfiguration implements Configuration {
      */
     void setValue(String key, String newValue) {
       newValue = eval.eval(newValue);
-      final CoreEntry oldEntry = entries.put(key, newValue);
+      final CoreEntry oldEntry = entries.put(key, newValue, Constants.USER_PROVIDED);
       if (oldEntry == null || !Objects.equals(newValue, oldEntry.value())) {
         config.fireOnChange(key, newValue);
       }
@@ -415,10 +415,10 @@ final class CoreConfiguration implements Configuration {
       if (value == null) {
         // defining property at runtime with System property backing
         String systemValue = System.getProperty(key);
-        value = systemValue != null ? CoreEntry.of(systemValue) : defaultValue != null ? CoreEntry.of(defaultValue) : CoreEntry.NULL_ENTRY;
+        value = systemValue != null ? CoreEntry.of(systemValue, "SystemProperty") : defaultValue != null ? CoreEntry.of(defaultValue, Constants.USER_PROVIDED_DEFAULT) : CoreEntry.NULL_ENTRY;
         entries.put(key, value);
       } else if (value.isNull() && defaultValue != null) {
-        value = CoreEntry.of(defaultValue);
+        value = CoreEntry.of(defaultValue, Constants.USER_PROVIDED_DEFAULT);
         entries.put(key, value);
       }
       return value;

--- a/avaje-config/src/main/java/io/avaje/config/CoreEntry.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreEntry.java
@@ -2,6 +2,7 @@ package io.avaje.config;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
@@ -27,16 +28,16 @@ final class CoreEntry {
   /**
    * Return a new empty entryMap for entries.
    */
-  static CoreEntryMap newMap() {
-    return new CoreEntry.CoreEntryMap();
+  static CoreMap newMap() {
+    return new CoreEntry.CoreMap();
   }
 
   /**
    * Return a new entryMap populated from the given Properties.
    * @param propSource where these properties came from
    */
-  static CoreEntryMap newMap(Properties source, String propSource) {
-    return new CoreEntry.CoreEntryMap(source, propSource);
+  static CoreMap newMap(Properties source, String propSource) {
+    return new CoreEntry.CoreMap(source, propSource);
   }
 
   /**
@@ -87,14 +88,14 @@ final class CoreEntry {
   /**
    * A entryMap like container of CoreEntry entries.
    */
-  static class CoreEntryMap {
+  static class CoreMap {
 
-    private final java.util.Map<String, CoreEntry> entryMap = new ConcurrentHashMap<>();
+    private final Map<String, CoreEntry> entryMap = new ConcurrentHashMap<>();
 
-    CoreEntryMap() {
+    CoreMap() {
     }
 
-    CoreEntryMap(Properties source, String propSource) {
+    CoreMap(Properties source, String propSource) {
       source.forEach((key, value) -> {
         if (value != null) {
           entryMap.put(key.toString(), CoreEntry.of(value.toString(), propSource));

--- a/avaje-config/src/main/java/io/avaje/config/CoreEntry.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreEntry.java
@@ -1,14 +1,13 @@
 package io.avaje.config;
 
-import io.avaje.lang.NonNullApi;
-import io.avaje.lang.Nullable;
+import static java.util.Objects.requireNonNull;
 
 import java.util.Properties;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 
-import static java.util.Objects.requireNonNull;
+import io.avaje.lang.NonNullApi;
+import io.avaje.lang.Nullable;
 
 /**
  * Configuration entry.
@@ -16,33 +15,35 @@ import static java.util.Objects.requireNonNull;
 @NonNullApi
 final class CoreEntry {
 
-  /**
+/**
    * Entry used to represent no entry / null.
    */
   static final CoreEntry NULL_ENTRY = new CoreEntry();
 
   private final String value;
   private final boolean boolValue;
+  private final String source;
 
   /**
-   * Return a new empty map for entries.
+   * Return a new empty entryMap for entries.
    */
-  static Map newMap() {
-    return new CoreEntry.Map();
+  static CoreEntryMap newMap() {
+    return new CoreEntry.CoreEntryMap();
   }
 
   /**
-   * Return a new map populated from the given Properties.
+   * Return a new entryMap populated from the given Properties.
+   * @param propSource where these properties came from
    */
-  static Map newMap(Properties source) {
-    return new CoreEntry.Map(source);
+  static CoreEntryMap newMap(Properties source, String propSource) {
+    return new CoreEntry.CoreEntryMap(source, propSource);
   }
 
   /**
    * Return an entry for the given value.
    */
-  static CoreEntry of(@Nullable String val) {
-    return val == null ? NULL_ENTRY : new CoreEntry(val);
+  static CoreEntry of(@Nullable String val, String source) {
+    return val == null ? NULL_ENTRY : new CoreEntry(val, source);
   }
 
   /**
@@ -51,12 +52,14 @@ final class CoreEntry {
   private CoreEntry() {
     this.value = null;
     this.boolValue = false;
+    this.source = null;
   }
 
-  private CoreEntry(String value) {
+  private CoreEntry(String value, String source) {
     requireNonNull(value);
     this.value = value;
     this.boolValue = Boolean.parseBoolean(value);
+    this.source = source;
   }
 
   String value() {
@@ -67,59 +70,69 @@ final class CoreEntry {
     return boolValue;
   }
 
+  String source() {
+    return source;
+  }
+
   boolean isNull() {
     return value == null;
   }
 
+
+  @Override
+  public String toString() {
+    return "CoreEntry [value=" + value + ", boolValue=" + boolValue + ", source=" + source + "]";
+  }
+
   /**
-   * A map like container of CoreEntry entries.
+   * A entryMap like container of CoreEntry entries.
    */
-  static class Map {
+  static class CoreEntryMap {
 
-    private final java.util.Map<String, CoreEntry> map = new ConcurrentHashMap<>();
+    private final java.util.Map<String, CoreEntry> entryMap = new ConcurrentHashMap<>();
 
-    Map() {
+    CoreEntryMap() {
     }
 
-    Map(Properties source) {
+    CoreEntryMap(Properties source, String propSource) {
       source.forEach((key, value) -> {
         if (value != null) {
-          map.put(key.toString(), CoreEntry.of(value.toString()));
+          entryMap.put(key.toString(), CoreEntry.of(value.toString(), propSource));
         }
       });
     }
 
     int size() {
-      return map.size();
+      return entryMap.size();
     }
 
     @Nullable
     CoreEntry get(String key) {
-      return map.get(key);
+      return entryMap.get(key);
     }
 
     void put(String key, CoreEntry value) {
-      map.put(key, value);
+      entryMap.put(key, value);
     }
 
     @Nullable
-    CoreEntry put(String key, String value) {
-      return map.put(key, CoreEntry.of(value));
+    CoreEntry put(String key, String value, String source) {
+      return entryMap.put(key, CoreEntry.of(value, source));
     }
 
     @Nullable
     CoreEntry remove(String key) {
-      return map.remove(key);
+      return entryMap.remove(key);
     }
 
     @Nullable
     String raw(String key) {
-      final CoreEntry entry = map.get(key);
+      final var entry = entryMap.get(key);
       return entry == null ? null : entry.value();
     }
 
     void forEach(BiConsumer<String, CoreEntry> consumer) {
-      map.forEach(consumer);
+      entryMap.forEach(consumer);
     }
   }
 }

--- a/avaje-config/src/main/java/io/avaje/config/CoreExpressionEval.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreExpressionEval.java
@@ -19,13 +19,13 @@ final class CoreExpressionEval implements Configuration.ExpressionEval {
    */
   private static final String END = "}";
 
-  private CoreEntry.CoreEntryMap sourceMap;
+  private CoreEntry.CoreMap sourceMap;
   private Properties sourceProperties;
 
   /**
    * Create with source map that can use used to eval expressions.
    */
-  CoreExpressionEval(CoreEntry.CoreEntryMap sourceMap) {
+  CoreExpressionEval(CoreEntry.CoreMap sourceMap) {
     this.sourceMap = sourceMap;
   }
 

--- a/avaje-config/src/main/java/io/avaje/config/CoreExpressionEval.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreExpressionEval.java
@@ -19,13 +19,13 @@ final class CoreExpressionEval implements Configuration.ExpressionEval {
    */
   private static final String END = "}";
 
-  private CoreEntry.Map sourceMap;
+  private CoreEntry.CoreEntryMap sourceMap;
   private Properties sourceProperties;
 
   /**
    * Create with source map that can use used to eval expressions.
    */
-  CoreExpressionEval(CoreEntry.Map sourceMap) {
+  CoreExpressionEval(CoreEntry.CoreEntryMap sourceMap) {
     this.sourceMap = sourceMap;
   }
 

--- a/avaje-config/src/main/java/io/avaje/config/InitialLoadContext.java
+++ b/avaje-config/src/main/java/io/avaje/config/InitialLoadContext.java
@@ -7,7 +7,7 @@ import java.io.InputStream;
 import java.lang.System.Logger.Level;
 import java.util.*;
 
-import io.avaje.config.CoreEntry.CoreEntryMap;
+import io.avaje.config.CoreEntry.CoreMap;
 
 /**
  * Manages the underlying map of properties we are gathering.
@@ -16,9 +16,9 @@ final class InitialLoadContext {
 
   private final EventLog log;
   /**
-   * CoreEntryMap we are loading the properties into.
+   * CoreMap we are loading the properties into.
    */
-  private final CoreEntry.CoreEntryMap map = CoreEntry.newMap();
+  private final CoreEntry.CoreMap map = CoreEntry.newMap();
 
   /**
    * Names of resources/files that were loaded.
@@ -121,7 +121,7 @@ final class InitialLoadContext {
   /**
    * Evaluate all the expressions and return as a Properties object.
    */
-  CoreEntryMap evalAll() {
+  CoreMap evalAll() {
     log.log(Level.TRACE, "load from {0}", loadedResources);
     var core = CoreEntry.newMap();
     map.forEach((key, entry) -> core.put(key, exprEval.eval(entry.value()), entry.source()));

--- a/avaje-config/src/main/java/io/avaje/config/InitialLoadContext.java
+++ b/avaje-config/src/main/java/io/avaje/config/InitialLoadContext.java
@@ -7,6 +7,8 @@ import java.io.InputStream;
 import java.lang.System.Logger.Level;
 import java.util.*;
 
+import io.avaje.config.CoreEntry.CoreEntryMap;
+
 /**
  * Manages the underlying map of properties we are gathering.
  */
@@ -14,9 +16,9 @@ final class InitialLoadContext {
 
   private final EventLog log;
   /**
-   * Map we are loading the properties into.
+   * CoreEntryMap we are loading the properties into.
    */
-  private final CoreEntry.Map map = CoreEntry.newMap();
+  private final CoreEntry.CoreEntryMap map = CoreEntry.newMap();
 
   /**
    * Names of resources/files that were loaded.
@@ -58,7 +60,7 @@ final class InitialLoadContext {
 
   private void initSystemProperty(String envValue, String key) {
     if (envValue != null && System.getProperty(key) == null) {
-      map.put(key, envValue);
+      map.put(key, envValue, Constants.ENV_VARIABLES);
     }
   }
 
@@ -109,21 +111,21 @@ final class InitialLoadContext {
   /**
    * Add a property entry.
    */
-  void put(String key, String val) {
+  void put(String key, String val, String source) {
     if (val != null) {
       val = val.trim();
     }
-    map.put(key, val);
+    map.put(key, val, source);
   }
 
   /**
    * Evaluate all the expressions and return as a Properties object.
    */
-  Properties evalAll() {
+  CoreEntryMap evalAll() {
     log.log(Level.TRACE, "load from {0}", loadedResources);
-    Properties properties = new Properties();
-    map.forEach((key, entry) -> properties.setProperty(key, exprEval.eval(entry.value())));
-    return properties;
+    var core = CoreEntry.newMap();
+    map.forEach((key, entry) -> core.put(key, exprEval.eval(entry.value()), entry.source()));
+    return core;
   }
 
   /**

--- a/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
+++ b/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
@@ -8,7 +8,7 @@ import java.util.Enumeration;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
-import io.avaje.config.CoreEntry.CoreEntryMap;
+import io.avaje.config.CoreEntry.CoreMap;
 
 import static io.avaje.config.InitialLoader.Source.FILE;
 import static io.avaje.config.InitialLoader.Source.RESOURCE;
@@ -81,7 +81,7 @@ final class InitialLoader {
    *   - application-test.yaml
    * </pre>
    */
-  CoreEntryMap load() {
+  CoreMap load() {
     loadEnvironmentVars();
     loadLocalFiles();
     return eval();
@@ -254,7 +254,7 @@ final class InitialLoader {
   /**
    * Evaluate all the configuration entries and return as properties.
    */
-  CoreEntryMap eval() {
+  CoreMap eval() {
     return loadContext.evalAll();
   }
 

--- a/avaje-config/src/test/java/io/avaje/config/CoreConfigurationTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/CoreConfigurationTest.java
@@ -3,7 +3,7 @@ package io.avaje.config;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import io.avaje.config.CoreEntry.CoreEntryMap;
+import io.avaje.config.CoreEntry.CoreMap;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -20,7 +20,7 @@ class CoreConfigurationTest {
 
   private final CoreConfiguration data = createSample();
 
-  private CoreEntryMap basicProperties() {
+  private CoreMap basicProperties() {
     Properties properties = new Properties();
     properties.setProperty("a", "1");
     properties.setProperty("foo.bar", "42");

--- a/avaje-config/src/test/java/io/avaje/config/CoreConfigurationTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/CoreConfigurationTest.java
@@ -3,6 +3,8 @@ package io.avaje.config;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import io.avaje.config.CoreEntry.CoreEntryMap;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
@@ -18,7 +20,7 @@ class CoreConfigurationTest {
 
   private final CoreConfiguration data = createSample();
 
-  private Properties basicProperties() {
+  private CoreEntryMap basicProperties() {
     Properties properties = new Properties();
     properties.setProperty("a", "1");
     properties.setProperty("foo.bar", "42");
@@ -28,16 +30,17 @@ class CoreConfigurationTest {
     properties.setProperty("someValues", "13,42,55");
     properties.setProperty("1someValues", "13,42,55");
     properties.setProperty("myEnum", "TWO");
-    return properties;
+
+    return CoreEntry.newMap(properties, "test");
   }
 
   private CoreConfiguration createSample() {
-    return new CoreConfiguration(new DefaultEventLog(), basicProperties());
+    return new CoreConfiguration(new DefaultEventLog(), basicProperties(),"Test");
   }
 
   @Test
   void asProperties() {
-    final Properties properties = basicProperties();
+    final var properties = basicProperties();
     System.setProperty("SetViaSystemProperty", "FooBar");
 
     final CoreConfiguration configuration = new CoreConfiguration(new DefaultEventLog(), properties);
@@ -85,7 +88,7 @@ class CoreConfigurationTest {
     properties.setProperty("oneNot", "fried");
     properties.setProperty("modify", "me");
 
-    CoreConfiguration base = new CoreConfiguration(new DefaultEventLog(), properties);
+    CoreConfiguration base = new CoreConfiguration(new DefaultEventLog(), CoreEntry.newMap(properties, "test"));
     assertThat(base.size()).isEqualTo(9);
 
     Configuration one = base.forPath("one");
@@ -106,7 +109,7 @@ class CoreConfigurationTest {
   @Test
   void test_toString() {
     assertThat(data.toString()).isNotEmpty();
-    data.setWatcher(new FileWatch( new CoreConfiguration(new DefaultEventLog(), new Properties()) , Collections.emptyList(), null));
+    data.setWatcher(new FileWatch( new CoreConfiguration(new DefaultEventLog(), CoreEntry.newMap(new Properties(), "test")) , Collections.emptyList(), null));
     data.loadIntoSystemProperties();
   }
 
@@ -325,30 +328,33 @@ class CoreConfigurationTest {
 
   @Test
   void evalProperties() {
-    final Properties properties = basicProperties();
-    properties.setProperty("someA", "before-${foo.bar}-after");
+    final var properties = basicProperties();
+    properties.put("someA", "before-${foo.bar}-after","eval");
 
-    final CoreConfiguration config = new CoreConfiguration(new DefaultEventLog(), new Properties());
-    final Properties copy = config.eval(properties);
+    final CoreConfiguration config = new CoreConfiguration(new DefaultEventLog(), CoreEntry.newMap(new Properties(), "test"));
+    
+    final var copy = config.eval(new CoreConfiguration(new DefaultEventLog(), properties).asProperties());
 
     assertThat(copy.getProperty("someA")).isEqualTo("before-42-after");
   }
 
   @Test
   void evalModify() {
-    final Properties properties = basicProperties();
+	final var properties = new CoreConfiguration(new DefaultEventLog(), basicProperties());
+
     properties.setProperty("someA", "before-${foo.bar}-after");
     properties.setProperty("yeahNah", "before-${no-eval-for-this}-after");
 
-    String beforeYeahNahValue = properties.getProperty("yeahNah");
+    String beforeYeahNahValue = properties.get("yeahNah");
 
-    final CoreConfiguration config = new CoreConfiguration(new DefaultEventLog(), new Properties());
-    config.evalModify(properties);
+    final CoreConfiguration config = new CoreConfiguration(new DefaultEventLog(), CoreEntry.newMap());
+   var props= properties.asProperties();
+    config.evalModify(props);
 
-    String someAValue = properties.getProperty("someA");
+    String someAValue = props.getProperty("someA");
     assertThat(someAValue).isEqualTo("before-42-after");
 
-    String afterYeahNahValue = properties.getProperty("yeahNah");
+    String afterYeahNahValue = props.getProperty("yeahNah");
     assertThat(beforeYeahNahValue).isSameAs(afterYeahNahValue);
   }
 }

--- a/avaje-config/src/test/java/io/avaje/config/CoreExpressionEvalTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/CoreExpressionEvalTest.java
@@ -83,9 +83,9 @@ class CoreExpressionEvalTest {
 
   @Test
   void eval_withSourceMap() {
-    CoreEntry.Map source = CoreEntry.newMap();
-    source.put("one", "1");
-    source.put("two", "2");
+    CoreEntry.CoreEntryMap source = CoreEntry.newMap();
+    source.put("one", "1","");
+    source.put("two", "2","");
     final CoreExpressionEval exprEval = new CoreExpressionEval(source);
 
     assertThat(exprEval.eval("foo${one}bar${two}baz${one}")).isEqualTo("foo1bar2baz1");

--- a/avaje-config/src/test/java/io/avaje/config/CoreExpressionEvalTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/CoreExpressionEvalTest.java
@@ -83,7 +83,7 @@ class CoreExpressionEvalTest {
 
   @Test
   void eval_withSourceMap() {
-    CoreEntry.CoreEntryMap source = CoreEntry.newMap();
+    CoreEntry.CoreMap source = CoreEntry.newMap();
     source.put("one", "1","");
     source.put("two", "2","");
     final CoreExpressionEval exprEval = new CoreExpressionEval(source);

--- a/avaje-config/src/test/java/io/avaje/config/FileWatchTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/FileWatchTest.java
@@ -161,7 +161,7 @@ class FileWatchTest {
     final Properties properties = new Properties();
     properties.setProperty("config.watch.delay", "1");
     properties.setProperty("config.watch.period", "1");
-    return new CoreConfiguration(new DefaultEventLog(), properties);
+    return new CoreConfiguration(new DefaultEventLog(),  CoreEntry.newMap(properties, "newConfig"));
   }
 
   private List<File> files() {

--- a/avaje-config/src/test/java/io/avaje/config/InitialLoaderTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/InitialLoaderTest.java
@@ -22,17 +22,17 @@ class InitialLoaderTest {
     loader.loadProperties("test-properties/one.properties", RESOURCE);
     loader.loadYaml("test-properties/foo.yml", RESOURCE);
 
-    Properties properties = loader.eval();
+    var properties = loader.eval();
 
-    assertEquals("fromProperties", properties.getProperty("app.fromProperties"));
-    assertEquals("Two", properties.getProperty("app.two"));
+    assertEquals("fromProperties", properties.get("app.fromProperties").value());
+    assertEquals("Two", properties.get("app.two").value());
 
-    assertEquals("bart", properties.getProperty("eval.withDefault"));
-    assertEquals(userName, properties.getProperty("eval.name"));
-    assertEquals(userHome + "/after", properties.getProperty("eval.home"));
+    assertEquals("bart", properties.get("eval.withDefault").value());
+    assertEquals(userName, properties.get("eval.name").value());
+    assertEquals(userHome + "/after", properties.get("eval.home").value());
 
-    assertEquals("before|Beta|after", properties.getProperty("someOne"));
-    assertEquals("before|Two|after", properties.getProperty("someTwo"));
+    assertEquals("before|Beta|after", properties.get("someOne").value());
+    assertEquals("before|Two|after", properties.get("someTwo").value());
   }
 
   @Test
@@ -42,19 +42,19 @@ class InitialLoaderTest {
     loader.loadWithExtensionCheck("test-dummy.yml");
     loader.loadWithExtensionCheck("test-dummy2.yaml");
 
-    Properties properties = loader.eval();
-    assertThat(properties.getProperty("dummy.yaml.bar")).isEqualTo("baz");
-    assertThat(properties.getProperty("dummy.yml.foo")).isEqualTo("bar");
-    assertThat(properties.getProperty("dummy.properties.foo")).isEqualTo("bar");
+    var properties = loader.eval();
+    assertThat(properties.get("dummy.yaml.bar").value()).isEqualTo("baz");
+    assertThat(properties.get("dummy.yml.foo").value()).isEqualTo("bar");
+    assertThat(properties.get("dummy.properties.foo").value()).isEqualTo("bar");
   }
 
   @Test
   void loadYaml() {
     InitialLoader loader = new InitialLoader(new DefaultEventLog());
     loader.loadYaml("test-properties/foo.yml", RESOURCE);
-    Properties properties = loader.eval();
+    var properties = loader.eval();
 
-    assertThat(properties.getProperty("Some.Other.pass")).isEqualTo("someDefault");
+    assertThat(properties.get("Some.Other.pass").value()).isEqualTo("someDefault");
   }
 
   @Test
@@ -64,14 +64,15 @@ class InitialLoaderTest {
 
     InitialLoader loader = new InitialLoader(new DefaultEventLog());
     loader.loadProperties("test-properties/one.properties", RESOURCE);
-    Properties properties = loader.eval();
-
-    assertThat(properties.getProperty("hello")).isEqualTo("there");
-    assertThat(properties.getProperty("name")).isEqualTo("Rob");
-    assertThat(properties.getProperty("statusPageUrl")).isEqualTo("https://host1:9876/status");
-    assertThat(properties.getProperty("statusPageUrl2")).isEqualTo("https://aaa:9876/status2");
-    assertThat(properties.getProperty("statusPageUrl3")).isEqualTo("https://aaa:89/status3");
-    assertThat(properties.getProperty("statusPageUrl4")).isEqualTo("https://there:9876/name/Rob");
+    var properties = loader.eval();
+    
+    assertThat(properties.get("hello").source()).isEqualTo("resource:test-properties/one.properties");
+    assertThat(properties.get("hello").value()).isEqualTo("there");
+    assertThat(properties.get("name").value()).isEqualTo("Rob");
+    assertThat(properties.get("statusPageUrl").value()).isEqualTo("https://host1:9876/status");
+    assertThat(properties.get("statusPageUrl2").value()).isEqualTo("https://aaa:9876/status2");
+    assertThat(properties.get("statusPageUrl3").value()).isEqualTo("https://aaa:89/status3");
+    assertThat(properties.get("statusPageUrl4").value()).isEqualTo("https://there:9876/name/Rob");
   }
 
   @Test
@@ -112,14 +113,14 @@ class InitialLoaderTest {
     try {
       System.setProperty("suppressTestResource", "");
       InitialLoader loader = new InitialLoader(new DefaultEventLog());
-      Properties properties = loader.load();
-      assertThat(properties.getProperty("myapp.activateFoo")).isEqualTo("true");
+      var properties = loader.load();
+      assertThat(properties.get("myapp.activateFoo").value()).isEqualTo("true");
 
       //application-test.yaml is not loaded when suppressTestResource is set to true
       System.setProperty("suppressTestResource", "true");
       InitialLoader loaderWithSuppressTestResource = new InitialLoader(new DefaultEventLog());
-      Properties propertiesWithoutTestResource = loaderWithSuppressTestResource.load();
-      assertThat(propertiesWithoutTestResource.getProperty("myapp.activateFoo")).isNull();
+      var propertiesWithoutTestResource = loaderWithSuppressTestResource.load();
+      assertThat(propertiesWithoutTestResource.get("myapp.activateFoo")).isNull();
     } finally {
       System.clearProperty("suppressTestResource");
     }


### PR DESCRIPTION
Now CoreEntry can provide where properties have come from.

- Rename CoreEntry.Map to CoreEntry.CoreMap
- modify CoreConfiguration to take CoreEntry.CoreMap over properties
- modify InitialLoader eval to return CoreEntry.CoreMap