### PR TITLE
Adds Event and EventBuilder where changes are made in batch/bulk and …

### DIFF
--- a/avaje-config/src/main/java/io/avaje/config/Config.java
+++ b/avaje-config/src/main/java/io/avaje/config/Config.java
@@ -419,6 +419,9 @@ public class Config {
 
   /**
    * Register an event listener that will be notified of configuration changes.
+   * <p>
+   * Events are created when configuration is changed via {@link #eventBuilder(String)}
+   * or when configuration is reload from its sources (watching file changes etc).
    *
    * @param eventListener The listener that is called when changes have occurred
    * @param keys          Optionally specify keys when the listener is only interested
@@ -429,18 +432,20 @@ public class Config {
   }
 
   /**
-   * Set a configuration value.
+   * Set a single configuration value. Note that {@link #eventBuilder(String)} should be
+   * used when setting multiple configuration values.
    * <p>
-   * This will fire an configuration callback listeners that are registered
-   * for this key.
-   * </p>
+   * This will fire configuration callback listeners that are registered.
    */
   public static void setProperty(String key, String value) {
     data.setProperty(key, value);
   }
 
   /**
-   * Clear the value for the given key.
+   * Clear the value for the given key. Note that {@link #eventBuilder(String)} should be
+   * used when setting multiple configuration values.
+   * <p>
+   * This will fire configuration callback listeners that are registered.
    *
    * @param key The configuration key we want to clear
    */

--- a/avaje-config/src/main/java/io/avaje/config/Config.java
+++ b/avaje-config/src/main/java/io/avaje/config/Config.java
@@ -399,6 +399,36 @@ public class Config {
   }
 
   /**
+   * Create an event builder to make changes to the configuration.
+   * <pre>{@code
+   *
+   *   configuration.eventBuilder("MyChanges")
+   *     .put("someKey", "val0")
+   *     .put("someOther.key", "42")
+   *     .remove("foo")
+   *     .publish();
+   *
+   * }</pre>
+   *
+   * @param name The name of the event which defines the source of the configuration value.
+   * @see #onChange(Consumer, String...)
+   */
+  public static EventBuilder eventBuilder(String name) {
+    return data.eventBuilder(name);
+  }
+
+  /**
+   * Register an event listener that will be notified of configuration changes.
+   *
+   * @param eventListener The listener that is called when changes have occurred
+   * @param keys          Optionally specify keys when the listener is only interested
+   *                      if changes are made for these specific properties
+   */
+  public static void onChange(Consumer<Event> eventListener, String... keys) {
+    data.onChange(eventListener, keys);
+  }
+
+  /**
    * Set a configuration value.
    * <p>
    * This will fire an configuration callback listeners that are registered

--- a/avaje-config/src/main/java/io/avaje/config/Configuration.java
+++ b/avaje-config/src/main/java/io/avaje/config/Configuration.java
@@ -289,6 +289,18 @@ public interface Configuration {
   }
 
   /**
+   * Create an event builder to make changes to the configuration.
+   *
+   * @param name The name of the event which defines the source of the configuration value.
+   */
+  EventBuilder eventBuilder(String name);
+
+  /**
+   * Register an event listener that will be notified of configuration changes.
+   */
+  void onChange(Consumer<Event> eventListener, String... keys);
+
+  /**
    * Set a configuration value.
    * <p>
    * This will fire configuration callback listeners that are registered for this key.

--- a/avaje-config/src/main/java/io/avaje/config/Configuration.java
+++ b/avaje-config/src/main/java/io/avaje/config/Configuration.java
@@ -306,6 +306,10 @@ public interface Configuration {
 
   /**
    * Register an event listener that will be notified of configuration changes.
+   * <p>
+   * Events are created when configuration is changed via {@link #eventBuilder(String)}
+   * or when configuration is reload from its sources (watching file changes etc).
+
    *
    * @param eventListener The listener that is called when changes have occurred
    * @param keys          Optionally specify keys when the listener is only interested
@@ -314,16 +318,18 @@ public interface Configuration {
   void onChange(Consumer<Event> eventListener, String... keys);
 
   /**
-   * Set a configuration value.
+   * Set a single configuration value. Note that {@link #eventBuilder(String)} should be
+   * used when setting multiple configuration values.
    * <p>
-   * This will fire configuration callback listeners that are registered for this key.
+   * This will fire configuration callback listeners that are registered.
    */
   void setProperty(String key, String value);
 
   /**
-   * Remove a configuration value for the given key.
+   * Clear the value for the given key. Note that {@link #eventBuilder(String)} should be
+   * used when setting multiple configuration values.
    * <p>
-   * This will fire configuration callback listeners that are registered for this key.
+   * This will fire configuration callback listeners that are registered.
    */
   void clearProperty(String key);
 

--- a/avaje-config/src/main/java/io/avaje/config/Configuration.java
+++ b/avaje-config/src/main/java/io/avaje/config/Configuration.java
@@ -179,7 +179,6 @@ public interface Configuration {
 
   /**
    * Return a URL configuration value with a default value. Deprecated, it's better to use URI over URL
-
    *
    * @param key          The configuration key
    * @param defaultValue The default value
@@ -290,13 +289,27 @@ public interface Configuration {
 
   /**
    * Create an event builder to make changes to the configuration.
+   * <pre>{@code
+   *
+   *   configuration.eventBuilder("MyChanges")
+   *     .put("someKey", "val0")
+   *     .put("someOther.key", "42")
+   *     .remove("foo")
+   *     .publish();
+   *
+   * }</pre>
    *
    * @param name The name of the event which defines the source of the configuration value.
+   * @see #onChange(Consumer, String...)
    */
   EventBuilder eventBuilder(String name);
 
   /**
    * Register an event listener that will be notified of configuration changes.
+   *
+   * @param eventListener The listener that is called when changes have occurred
+   * @param keys          Optionally specify keys when the listener is only interested
+   *                      if changes are made for these specific properties
    */
   void onChange(Consumer<Event> eventListener, String... keys);
 

--- a/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
@@ -11,6 +11,7 @@ import java.net.URL;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 import java.util.function.LongConsumer;
@@ -27,7 +28,7 @@ final class CoreConfiguration implements Configuration {
 
   private final EventLog log;
   private final ModifyAwareProperties properties;
-  private final List<CoreListener> listeners = new ArrayList<>();
+  private final List<CoreListener> listeners = new CopyOnWriteArrayList<>();
 
   private final Map<String, OnChangeListener> callbacks = new ConcurrentHashMap<>();
   private final CoreListValue listValue;

--- a/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
@@ -111,6 +111,10 @@ final class CoreConfiguration implements Configuration {
     }
   }
 
+  String eval(String value) {
+    return properties.eval(value);
+  }
+
   @Override
   public Properties eval(Properties source) {
     final ExpressionEval exprEval = InitialLoader.evalFor(source);
@@ -397,6 +401,10 @@ final class CoreConfiguration implements Configuration {
 
     int size() {
       return entries.size();
+    }
+
+    String eval(String value) {
+      return eval.eval(value);
     }
 
     /**

--- a/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
@@ -92,11 +92,6 @@ final class CoreConfiguration implements Configuration {
   }
 
   @Override
-  public String toString() {
-    return watcher == null ? properties.toString() : "watcher:" + watcher + " " + properties;
-  }
-
-  @Override
   public int size() {
     return properties.size();
   }
@@ -391,11 +386,6 @@ final class CoreConfiguration implements Configuration {
     ModifyAwareProperties(CoreEntry.CoreMap entries) {
       this.entries = entries;
       this.eval = new CoreExpressionEval(entries);
-    }
-
-    @Override
-    public String toString() {
-      return entries.toString();
     }
 
     int size() {

--- a/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
@@ -37,13 +37,13 @@ final class CoreConfiguration implements Configuration {
   private Timer timer;
   private final String pathPrefix;
 
-  CoreConfiguration(EventLog log, CoreEntry.CoreMap source) {
-    this(log, source, "");
+  CoreConfiguration(EventLog log, CoreEntry.CoreMap entries) {
+    this(log, entries, "");
   }
 
-  CoreConfiguration(EventLog log, CoreEntry.CoreMap source, String prefix) {
+  CoreConfiguration(EventLog log, CoreEntry.CoreMap entries, String prefix) {
     this.log = log;
-    this.properties = new ModifyAwareProperties(this, source);
+    this.properties = new ModifyAwareProperties(entries);
     this.listValue = new CoreListValue(this);
     this.setValue = new CoreSetValue(this);
     this.pathPrefix = prefix;
@@ -302,7 +302,7 @@ final class CoreConfiguration implements Configuration {
   @Override
   public EventBuilder eventBuilder(String name) {
     requireNonNull(name);
-    return new CoreEventBuilder(name, this, properties.copy());
+    return new CoreEventBuilder(name, this, properties.entryMap());
   }
 
   void publishEvent(CoreEventBuilder eventBuilder) {
@@ -387,10 +387,8 @@ final class CoreConfiguration implements Configuration {
 
     private final CoreEntry.CoreMap entries;
     private final Configuration.ExpressionEval eval;
-    private final CoreConfiguration config;
 
-    ModifyAwareProperties(CoreConfiguration config, CoreEntry.CoreMap entries) {
-      this.config = config;
+    ModifyAwareProperties(CoreEntry.CoreMap entries) {
       this.entries = entries;
       this.eval = new CoreExpressionEval(entries);
     }
@@ -466,11 +464,8 @@ final class CoreConfiguration implements Configuration {
       return props;
     }
 
-    /**
-     * Return a copy of the internal map.
-     */
-    CoreEntry.CoreMap copy() {
-      return entries.copy();
+    CoreEntry.CoreMap entryMap() {
+      return entries;
     }
 
     Set<String> applyChanges(CoreEventBuilder eventBuilder) {

--- a/avaje-config/src/main/java/io/avaje/config/CoreEntry.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreEntry.java
@@ -79,11 +79,6 @@ final class CoreEntry {
     return value == null;
   }
 
-  @Override
-  public String toString() {
-    return isNull() ? "NullEntry" : "Entry[value=" + value + ", source=" + source + "]";
-  }
-
   /**
    * A entryMap like container of CoreEntry entries.
    */
@@ -101,11 +96,6 @@ final class CoreEntry {
           entryMap.put(key.toString(), CoreEntry.of(value.toString(), sourceName));
         }
       });
-    }
-
-    @Override
-    public String toString() {
-      return "size:" + entryMap.size() + " entries:" + entryMap;
     }
 
     int size() {

--- a/avaje-config/src/main/java/io/avaje/config/CoreEntry.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreEntry.java
@@ -95,23 +95,12 @@ final class CoreEntry {
     CoreMap() {
     }
 
-    /**
-     * Copy constructor.
-     */
-    CoreMap(CoreMap source) {
-      entryMap.putAll(source.entryMap);
-    }
-
     CoreMap(Properties source, String propSource) {
       source.forEach((key, value) -> {
         if (value != null) {
           entryMap.put(key.toString(), CoreEntry.of(value.toString(), propSource));
         }
       });
-    }
-
-    CoreMap copy() {
-      return new CoreMap(this);
     }
 
     @Override
@@ -141,8 +130,7 @@ final class CoreEntry {
             if (entryMap.remove(key) != null) {
               modifiedKeys.add(key);
             }
-          }
-          if (putIfChanged(key, value, sourceName)) {
+          } else if (putIfChanged(key, value, sourceName)) {
             modifiedKeys.add(key);
           }
         });
@@ -184,14 +172,8 @@ final class CoreEntry {
       entryMap.put(key, value);
     }
 
-    @Nullable
-    CoreEntry put(String key, String value, String source) {
-      return entryMap.put(key, CoreEntry.of(value, source));
-    }
-
-    @Nullable
-    CoreEntry remove(String key) {
-      return entryMap.remove(key);
+    void put(String key, String value, String source) {
+      entryMap.put(key, CoreEntry.of(value, source));
     }
 
     @Nullable

--- a/avaje-config/src/main/java/io/avaje/config/CoreEntry.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreEntry.java
@@ -95,10 +95,10 @@ final class CoreEntry {
     CoreMap() {
     }
 
-    CoreMap(Properties source, String propSource) {
+    CoreMap(Properties source, String sourceName) {
       source.forEach((key, value) -> {
         if (value != null) {
-          entryMap.put(key.toString(), CoreEntry.of(value.toString(), propSource));
+          entryMap.put(key.toString(), CoreEntry.of(value.toString(), sourceName));
         }
       });
     }

--- a/avaje-config/src/main/java/io/avaje/config/CoreEvent.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreEvent.java
@@ -1,0 +1,31 @@
+package io.avaje.config;
+
+import java.util.Set;
+
+final class CoreEvent implements Event {
+
+  private final String name;
+  private final Set<String> modifiedKeys;
+  private final CoreConfiguration origin;
+
+  CoreEvent(String name, Set<String> modifiedKeys, CoreConfiguration origin) {
+    this.name = name;
+    this.modifiedKeys = modifiedKeys;
+    this.origin = origin;
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public Configuration configuration() {
+    return origin;
+  }
+
+  @Override
+  public Set<String> modifiedKeys() {
+    return modifiedKeys;
+  }
+}

--- a/avaje-config/src/main/java/io/avaje/config/CoreEventBuilder.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreEventBuilder.java
@@ -23,6 +23,7 @@ final class CoreEventBuilder implements EventBuilder {
   public EventBuilder put(String key, String value) {
     requireNonNull(key);
     requireNonNull(value);
+    value = origin.eval(value);
     if (snapshot.isChanged(key, value)) {
       changes.put(key, value);
     }

--- a/avaje-config/src/main/java/io/avaje/config/CoreEventBuilder.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreEventBuilder.java
@@ -1,0 +1,57 @@
+package io.avaje.config;
+
+import java.util.*;
+import java.util.function.BiConsumer;
+
+import static java.util.Objects.requireNonNull;
+
+final class CoreEventBuilder implements EventBuilder {
+
+  private final String name;
+  private final CoreConfiguration origin;
+  private final CoreEntry.CoreMap snapshot;
+  private final Map<String, String> changes = new LinkedHashMap<>();
+
+
+  CoreEventBuilder(String name, CoreConfiguration origin, CoreEntry.CoreMap snapshot) {
+    this.name = name;
+    this.origin = origin;
+    this.snapshot = snapshot; // at the moment we don't mutate the snapshot so could just use the original map
+  }
+
+  @Override
+  public EventBuilder put(String key, String value) {
+    requireNonNull(key);
+    requireNonNull(value);
+    if (snapshot.isChanged(key, value)) {
+      changes.put(key, value);
+    }
+    return this;
+  }
+
+  @Override
+  public EventBuilder remove(String key) {
+    requireNonNull(key);
+    if (snapshot.containsKey(key)) {
+      changes.put(key, null);
+    }
+    return this;
+  }
+
+  @Override
+  public void publish() {
+    origin.publishEvent(this);
+  }
+
+  boolean hasChanges() {
+    return !changes.isEmpty();
+  }
+
+  void forEachPut(BiConsumer<String, String> consumer) {
+    changes.forEach(consumer);
+  }
+
+  String name() {
+    return name;
+  }
+}

--- a/avaje-config/src/main/java/io/avaje/config/CoreListener.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreListener.java
@@ -1,0 +1,33 @@
+package io.avaje.config;
+
+import java.util.function.Consumer;
+
+/**
+ * Wraps the listener taking the interesting keys into account.
+ */
+final class CoreListener {
+
+  private final Consumer<Event> listener;
+  private final String[] keys;
+
+  CoreListener(Consumer<Event> listener, String[] keys) {
+    this.listener = listener;
+    this.keys = keys;
+  }
+
+  void accept(CoreEvent event) {
+    if (keys == null || keys.length == 0  || containsKey(event)) {
+      listener.accept(event);
+    }
+  }
+
+  private boolean containsKey(CoreEvent event) {
+    final var modifiedKeys = event.modifiedKeys();
+    for (String key : keys) {
+      if (modifiedKeys.contains(key)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/avaje-config/src/main/java/io/avaje/config/Event.java
+++ b/avaje-config/src/main/java/io/avaje/config/Event.java
@@ -1,0 +1,12 @@
+package io.avaje.config;
+
+import java.util.Set;
+
+public interface Event {
+
+  String name();
+
+  Configuration configuration();
+
+  Set<String> modifiedKeys();
+}

--- a/avaje-config/src/main/java/io/avaje/config/Event.java
+++ b/avaje-config/src/main/java/io/avaje/config/Event.java
@@ -1,12 +1,29 @@
 package io.avaje.config;
 
 import java.util.Set;
+import java.util.function.Consumer;
 
+/**
+ * The event that occurs on configuration changes. Register to listen for these events
+ * via {@link Configuration#onChange(Consumer, String...)}.
+ *
+ * @see Configuration#eventBuilder(String)
+ * @see Configuration#onChange(Consumer, String...)
+ */
 public interface Event {
 
+  /**
+   * Return the name of the event (e.g "reload").
+   */
   String name();
 
+  /**
+   * Return the updated configuration.
+   */
   Configuration configuration();
 
+  /**
+   * Return the set of keys where the properties where modified.
+   */
   Set<String> modifiedKeys();
 }

--- a/avaje-config/src/main/java/io/avaje/config/EventBuilder.java
+++ b/avaje-config/src/main/java/io/avaje/config/EventBuilder.java
@@ -1,0 +1,11 @@
+package io.avaje.config;
+
+public interface EventBuilder {
+
+  EventBuilder put(String key, String value);
+
+  EventBuilder remove(String key);
+
+  void publish();
+
+}

--- a/avaje-config/src/main/java/io/avaje/config/EventBuilder.java
+++ b/avaje-config/src/main/java/io/avaje/config/EventBuilder.java
@@ -1,11 +1,41 @@
 package io.avaje.config;
 
+import java.util.function.Consumer;
+
+/**
+ * Build and publish modifications to the configuration.
+ * <pre>{@code
+ *
+ *   configuration.eventBuilder("MyChanges")
+ *     .put("someKey", "val0")
+ *     .put("someOther.key", "42")
+ *     .remove("foo")
+ *     .publish();
+ *
+ * }</pre>
+ *
+ * @see Configuration#eventBuilder(String)
+ * @see Configuration#onChange(Consumer, String...)
+ */
 public interface EventBuilder {
 
+  /**
+   * Set a property value.
+   *
+   * @param key The property key
+   * @param value The new value of the property
+   */
   EventBuilder put(String key, String value);
 
+  /**
+   * Remove a property from the configuration.
+   */
   EventBuilder remove(String key);
 
+  /**
+   * Publish the changes. Listeners registered via {@link Configuration#onChange(Consumer, String...)}
+   * will be notified on the changes.
+   */
   void publish();
 
 }

--- a/avaje-config/src/test/java/io/avaje/config/ConfigTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/ConfigTest.java
@@ -53,7 +53,34 @@ class ConfigTest {
   void setProperty() {
     assertThat(Config.getOptional("MySystemProp3")).isEmpty();
     Config.setProperty("MySystemProp3", "hello2");
+
     assertThat(Config.get("MySystemProp3")).isEqualTo("hello2");
+    Config.clearProperty("MySystemProp3");
+  }
+
+  @Test
+  void eventBuilderPublish() {
+    assertThat(Config.getOptional("MySystemProp4")).isEmpty();
+    Config.eventBuilder("MyChange").put("MySystemProp4", "hello4").publish();
+
+    assertThat(Config.get("MySystemProp4")).isEqualTo("hello4");
+    Config.clearProperty("MySystemProp4");
+  }
+
+  @Test
+  void onChangeEventListener() {
+    assertThat(Config.getOptional("MySystemProp5")).isEmpty();
+    AtomicReference<Event> capturedEvent = new AtomicReference<>();
+    Config.onChange((capturedEvent::set));
+    Config.setProperty("MySystemProp5", "hi5");
+
+    Event event = capturedEvent.get();
+
+    assertThat(event.name()).isEqualTo("SetProperty");
+    assertThat(event.modifiedKeys()).containsExactly("MySystemProp5");
+    assertThat(Config.get("MySystemProp5")).isEqualTo("hi5");
+
+    Config.clearProperty("MySystemProp5");
   }
 
   @Test

--- a/avaje-config/src/test/java/io/avaje/config/CoreConfigurationTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/CoreConfigurationTest.java
@@ -106,9 +106,8 @@ class CoreConfigurationTest {
 
   @Test
   void test_toString() {
-    assertThat(data.toString()).isNotEmpty();
     data.setWatcher(new FileWatch( new CoreConfiguration(new DefaultEventLog(), CoreEntry.newMap(new Properties(), "test")) , Collections.emptyList(), null));
-    assertThat(data.toString()).contains("watcher");
+    assertThat(data.toString()).doesNotContain("entries");
   }
 
   @Test

--- a/avaje-config/src/test/java/io/avaje/config/CoreConfigurationTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/CoreConfigurationTest.java
@@ -48,6 +48,7 @@ class CoreConfigurationTest {
     assertThat(loaded.get("SetViaSystemProperty")).isNull();
 
     System.clearProperty("SetViaSystemProperty");
+    System.clearProperty("foo.bar");
   }
 
   @Test

--- a/avaje-config/src/test/java/io/avaje/config/CoreConfigurationTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/CoreConfigurationTest.java
@@ -260,7 +260,7 @@ class CoreConfigurationTest {
     data.eventBuilder("myTest")
       .put("a", "1") // not actually a change
       .put("onChangeTest_1", "one")
-      .put("onChangeTest_1.2", "two")
+      .put("onChangeTest_1.2", "two|${user.home}|be")
       .remove("onChange_doesNotExist")
       .remove("foo.bar")
       .publish();
@@ -276,8 +276,9 @@ class CoreConfigurationTest {
     assertThat(configuration.getOptional("foo.bar")).isEmpty();
     assertThat(data.getOptional("foo.bar")).isEmpty();
 
+    String userHome = System.getProperty("user.home");
     assertThat(configuration.get("onChangeTest_1")).isEqualTo("one");
-    assertThat(configuration.get("onChangeTest_1.2")).isEqualTo("two");
+    assertThat(configuration.get("onChangeTest_1.2")).isEqualTo("two|" + userHome+ "|be");
 
 
     assertThat(capturedEventsNoKeyMatch).isEmpty();

--- a/avaje-config/src/test/java/io/avaje/config/CoreConfigurationTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/CoreConfigurationTest.java
@@ -5,10 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Properties;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -110,7 +107,7 @@ class CoreConfigurationTest {
   void test_toString() {
     assertThat(data.toString()).isNotEmpty();
     data.setWatcher(new FileWatch( new CoreConfiguration(new DefaultEventLog(), CoreEntry.newMap(new Properties(), "test")) , Collections.emptyList(), null));
-    data.loadIntoSystemProperties();
+    assertThat(data.toString()).contains("watcher");
   }
 
   @Test


### PR DESCRIPTION
…onChange() listener gets all the changes after they are all applied

- Leaves all the existing setProperty(), clearProperty(), onChange(<single property>) in place and unchanged
- With the current approach could remove the 'snapshot copy' as EventBuilder has no get() read methods