### PR TITLE
Add tests/examples with onChange 'single property' via ModificationEvent

### DIFF
--- a/avaje-config/src/main/java/io/avaje/config/Config.java
+++ b/avaje-config/src/main/java/io/avaje/config/Config.java
@@ -443,14 +443,11 @@ public class Config {
    * Register an event listener that will be notified of configuration changes.
    * <p>
    * If we are only interested in changes to a single property it is easier to use
-   * {@link #onChange(String, Consumer)} or the variants for int, long, boolean.
+   * {@link #onChange(String, Consumer)} or the variants for int, long, boolean
+   * onChangeInt(), onChangeLong(), onChangeBool().
    * <p>
    * Typically, we use this when we are interested in changes to multiple properties
    * and want to get and act on the values of multiple properties.
-   * <p>
-   * Events are created when configuration is changed via {@link #eventBuilder(String)},
-   * {@link #setProperty(String, String)}, {@link #clearProperty(String)} or when
-   * configuration is reloaded from its sources (e.g. watching file changes).
    *
    * <pre>{@code
    *  configuration.onChange((modificationEvent) -> {
@@ -494,14 +491,11 @@ public class Config {
    *
    * <pre>{@code
    *
-   *   AtomicReference<String> value = new AtomicReference<>("initial");
+   *   configuration.onChange("myKey", (neValue) -> {
    *
-   *   configuration.onChange("myKey", (newStringValue) -> {
-   *     value.set(newStringValue);
+   *     // do something with the newValue ...
+   *
    *   ));
-   *
-   *   // using a method reference
-   *   configuration.onChange("myKey", value::set);
    *
    * }</pre>
    *

--- a/avaje-config/src/main/java/io/avaje/config/Config.java
+++ b/avaje-config/src/main/java/io/avaje/config/Config.java
@@ -418,20 +418,6 @@ public class Config {
   }
 
   /**
-   * Register an event listener that will be notified of configuration changes.
-   * <p>
-   * Events are created when configuration is changed via {@link #eventBuilder(String)}
-   * or when configuration is reload from its sources (watching file changes etc).
-   *
-   * @param eventListener The listener that is called when changes have occurred
-   * @param keys          Optionally specify keys when the listener is only interested
-   *                      if changes are made for these specific properties
-   */
-  public static void onChange(Consumer<ModificationEvent> eventListener, String... keys) {
-    data.onChange(eventListener, keys);
-  }
-
-  /**
    * Set a single configuration value. Note that {@link #eventBuilder(String)} should be
    * used when setting multiple configuration values.
    * <p>
@@ -451,6 +437,20 @@ public class Config {
    */
   public static void clearProperty(String key) {
     data.clearProperty(key);
+  }
+
+  /**
+   * Register an event listener that will be notified of configuration changes.
+   * <p>
+   * Events are created when configuration is changed via {@link #eventBuilder(String)}
+   * or when configuration is reload from its sources (watching file changes etc).
+   *
+   * @param eventListener The listener that is called when changes have occurred
+   * @param keys          Optionally specify keys when the listener is only interested
+   *                      if changes are made for these specific properties
+   */
+  public static void onChange(Consumer<ModificationEvent> eventListener, String... keys) {
+    data.onChange(eventListener, keys);
   }
 
   /**
@@ -474,7 +474,7 @@ public class Config {
   }
 
   /**
-   * Register a callback for a change to the given configuration key as an Long value.
+   * Register a callback for a change to the given configuration key as a Long value.
    *
    * @param key      The configuration key we want to detect changes to
    * @param callback The callback handling to fire when the configuration changes.
@@ -484,7 +484,7 @@ public class Config {
   }
 
   /**
-   * Register a callback for a change to the given configuration key as an Boolean value.
+   * Register a callback for a change to the given configuration key as a Boolean value.
    *
    * @param key      The configuration key we want to detect changes to
    * @param callback The callback handling to fire when the configuration changes.

--- a/avaje-config/src/main/java/io/avaje/config/Config.java
+++ b/avaje-config/src/main/java/io/avaje/config/Config.java
@@ -442,54 +442,112 @@ public class Config {
   /**
    * Register an event listener that will be notified of configuration changes.
    * <p>
-   * Events are created when configuration is changed via {@link #eventBuilder(String)}
-   * or when configuration is reload from its sources (watching file changes etc).
+   * If we are only interested in changes to a single property it is easier to use
+   * {@link #onChange(String, Consumer)} or the variants for int, long, boolean.
+   * <p>
+   * Typically, we use this when we are interested in changes to multiple properties
+   * and want to get and act on the values of multiple properties.
+   * <p>
+   * Events are created when configuration is changed via {@link #eventBuilder(String)},
+   * {@link #setProperty(String, String)}, {@link #clearProperty(String)} or when
+   * configuration is reloaded from its sources (e.g. watching file changes).
    *
-   * @param eventListener The listener that is called when changes have occurred
-   * @param keys          Optionally specify keys when the listener is only interested
-   *                      if changes are made for these specific properties
+   * <pre>{@code
+   *  configuration.onChange((modificationEvent) -> {
+   *
+   *    String newValue = modificationEvent.configuration().get("myFirstKey");
+   *    int newInt = modificationEvent.configuration().getInt("myOtherKey");
+   *    // do something ...
+   *
+   *  });
+   *
+   *  }</pre>
+   * <p>
+   * When we are only interested if some specific properties have changed then we
+   * can define those. The event listener will be invoked if there is a change to
+   * any of those keys.
+   *
+   * <pre>{@code
+   *  configuration.onChange((event) -> {
+   *
+   *    String newValue = event.configuration().get("myFirstInterestingKey");
+   *    int newInt = event.configuration().getInt("myOtherInterestingKey");
+   *    // do something ...
+   *
+   *  }, "myFirstInterestingKey", "myOtherInterestingKey");
+   *
+   *  }</pre>
+   *
+   * @param bulkChangeEventListener The listener that is called when changes have occurred
+   * @param keys                    Optionally specify keys when the listener is only interested
+   *                                if changes are made for these specific properties
    */
-  public static void onChange(Consumer<ModificationEvent> eventListener, String... keys) {
-    data.onChange(eventListener, keys);
+  public static void onChange(Consumer<ModificationEvent> bulkChangeEventListener, String... keys) {
+    data.onChange(bulkChangeEventListener, keys);
   }
 
   /**
    * Register a callback for a change to the given configuration key.
+   * <p>
+   * Use this when we are only interested in changes to a single configuration property.
+   * If we are interested in multiple properties we should use {@link #onChange(Consumer, String...)}
    *
-   * @param key      The configuration key we want to detect changes to
-   * @param callback The callback handling to fire when the configuration changes.
+   * <pre>{@code
+   *
+   *   AtomicReference<String> value = new AtomicReference<>("initial");
+   *
+   *   configuration.onChange("myKey", (newStringValue) -> {
+   *     value.set(newStringValue);
+   *   ));
+   *
+   *   // using a method reference
+   *   configuration.onChange("myKey", value::set);
+   *
+   * }</pre>
+   *
+   * @param key                          The configuration key we want to detect changes to
+   * @param singlePropertyChangeListener The callback handling to fire when the configuration changes.
    */
-  public static void onChange(String key, Consumer<String> callback) {
-    data.onChange(key, callback);
+  public static void onChange(String key, Consumer<String> singlePropertyChangeListener) {
+    data.onChange(key, singlePropertyChangeListener);
   }
 
   /**
    * Register a callback for a change to the given configuration key as an Int value.
+   * <p>
+   * Use this when we are only interested in changes to a single configuration property.
+   * If we are interested in multiple properties we should use {@link #onChange(Consumer, String...)}
    *
-   * @param key      The configuration key we want to detect changes to
-   * @param callback The callback handling to fire when the configuration changes.
+   * @param key                          The configuration key we want to detect changes to
+   * @param singlePropertyChangeListener The callback handling to fire when the configuration changes.
    */
-  public static void onChangeInt(String key, IntConsumer callback) {
-    data.onChangeInt(key, callback);
+  public static void onChangeInt(String key, IntConsumer singlePropertyChangeListener) {
+    data.onChangeInt(key, singlePropertyChangeListener);
   }
 
   /**
    * Register a callback for a change to the given configuration key as a Long value.
+   * <p>
+   * Use this when we are only interested in changes to a single configuration property.
+   * If we are interested in multiple properties we should use {@link #onChange(Consumer, String...)}
    *
-   * @param key      The configuration key we want to detect changes to
-   * @param callback The callback handling to fire when the configuration changes.
+   * @param key                          The configuration key we want to detect changes to
+   * @param singlePropertyChangeListener The callback handling to fire when the configuration changes.
    */
-  public static void onChangeLong(String key, LongConsumer callback) {
-    data.onChangeLong(key, callback);
+  public static void onChangeLong(String key, LongConsumer singlePropertyChangeListener) {
+    data.onChangeLong(key, singlePropertyChangeListener);
   }
 
   /**
    * Register a callback for a change to the given configuration key as a Boolean value.
+   * <p>
+   * Use this when we are only interested in changes to a single configuration property.
+   * If we are interested in multiple properties we should use {@link #onChange(Consumer, String...)}
    *
-   * @param key      The configuration key we want to detect changes to
-   * @param callback The callback handling to fire when the configuration changes.
+   * @param key                          The configuration key we want to detect changes to
+   * @param singlePropertyChangeListener The callback handling to fire when the configuration changes.
    */
-  public static void onChangeBool(String key, Consumer<Boolean> callback) {
-    data.onChangeBool(key, callback);
+  public static void onChangeBool(String key, Consumer<Boolean> singlePropertyChangeListener) {
+    data.onChangeBool(key, singlePropertyChangeListener);
   }
 }

--- a/avaje-config/src/main/java/io/avaje/config/Configuration.java
+++ b/avaje-config/src/main/java/io/avaje/config/Configuration.java
@@ -305,19 +305,6 @@ public interface Configuration {
   ModificationEvent.Builder eventBuilder(String name);
 
   /**
-   * Register an event listener that will be notified of configuration changes.
-   * <p>
-   * Events are created when configuration is changed via {@link #eventBuilder(String)}
-   * or when configuration is reload from its sources (watching file changes etc).
-
-   *
-   * @param eventListener The listener that is called when changes have occurred
-   * @param keys          Optionally specify keys when the listener is only interested
-   *                      if changes are made for these specific properties
-   */
-  void onChange(Consumer<ModificationEvent> eventListener, String... keys);
-
-  /**
    * Set a single configuration value. Note that {@link #eventBuilder(String)} should be
    * used when setting multiple configuration values.
    * <p>
@@ -332,6 +319,19 @@ public interface Configuration {
    * This will fire configuration callback listeners that are registered.
    */
   void clearProperty(String key);
+
+  /**
+   * Register an event listener that will be notified of configuration changes.
+   * <p>
+   * Events are created when configuration is changed via {@link #eventBuilder(String)}
+   * or when configuration is reload from its sources (watching file changes etc).
+
+   *
+   * @param eventListener The listener that is called when changes have occurred
+   * @param keys          Optionally specify keys when the listener is only interested
+   *                      if changes are made for these specific properties
+   */
+  void onChange(Consumer<ModificationEvent> eventListener, String... keys);
 
   /**
    * Register a callback for a change to the given configuration key.
@@ -350,7 +350,7 @@ public interface Configuration {
   void onChangeInt(String key, IntConsumer callback);
 
   /**
-   * Register a callback for a change to the given configuration key as an Long value.
+   * Register a callback for a change to the given configuration key as a Long value.
    *
    * @param key      The configuration key we want to detect changes to
    * @param callback The callback handling to fire when the configuration changes.
@@ -358,7 +358,7 @@ public interface Configuration {
   void onChangeLong(String key, LongConsumer callback);
 
   /**
-   * Register a callback for a change to the given configuration key as an Boolean value.
+   * Register a callback for a change to the given configuration key as a Boolean value.
    *
    * @param key      The configuration key we want to detect changes to
    * @param callback The callback handling to fire when the configuration changes.

--- a/avaje-config/src/main/java/io/avaje/config/Configuration.java
+++ b/avaje-config/src/main/java/io/avaje/config/Configuration.java
@@ -323,47 +323,104 @@ public interface Configuration {
   /**
    * Register an event listener that will be notified of configuration changes.
    * <p>
-   * Events are created when configuration is changed via {@link #eventBuilder(String)}
-   * or when configuration is reload from its sources (watching file changes etc).
-
+   * If we are only interested in changes to a single property it is easier to use
+   * {@link #onChange(String, Consumer)} or the variants for int, long, boolean.
+   * <p>
+   * Typically, we use this when we are interested in changes to multiple properties
+   * and want to get and act on the values of multiple properties.
+   * <p>
+   * Events are created when configuration is changed via {@link #eventBuilder(String)},
+   * {@link #setProperty(String, String)}, {@link #clearProperty(String)} or when
+   * configuration is reloaded from its sources (e.g. watching file changes).
    *
-   * @param eventListener The listener that is called when changes have occurred
-   * @param keys          Optionally specify keys when the listener is only interested
-   *                      if changes are made for these specific properties
+   * <pre>{@code
+   *  configuration.onChange((modificationEvent) -> {
+   *
+   *    String newValue = modificationEvent.configuration().get("myFirstKey");
+   *    int newInt = modificationEvent.configuration().getInt("myOtherKey");
+   *    // do something ...
+   *
+   *  });
+   *
+   *  }</pre>
+   * <p>
+   * When we are only interested if some specific properties have changed then we
+   * can define those. The event listener will be invoked if there is a change to
+   * any of those keys.
+   *
+   * <pre>{@code
+   *  configuration.onChange((event) -> {
+   *
+   *    String newValue = event.configuration().get("myFirstInterestingKey");
+   *    int newInt = event.configuration().getInt("myOtherInterestingKey");
+   *    // do something ...
+   *
+   *  }, "myFirstInterestingKey", "myOtherInterestingKey");
+   *
+   *  }</pre>
+   *
+   * @param bulkChangeEventListener The listener that is called when changes have occurred
+   * @param keys                    Optionally specify keys when the listener is only interested
+   *                                if changes are made for these specific properties
    */
-  void onChange(Consumer<ModificationEvent> eventListener, String... keys);
+  void onChange(Consumer<ModificationEvent> bulkChangeEventListener, String... keys);
 
   /**
    * Register a callback for a change to the given configuration key.
+   * <p>
+   * Use this when we are only interested in changes to a single configuration property.
+   * If we are interested in multiple properties we should use {@link #onChange(Consumer, String...)}
    *
-   * @param key      The configuration key we want to detect changes to
-   * @param callback The callback handling to fire when the configuration changes.
+   * <pre>{@code
+   *
+   *   AtomicReference<String> value = new AtomicReference<>("initial");
+   *
+   *   configuration.onChange("myKey", (newStringValue) -> {
+   *     value.set(newStringValue);
+   *   ));
+   *
+   *   // using a method reference
+   *   configuration.onChange("myKey", value::set);
+   *
+   * }</pre>
+   *
+   * @param key                          The configuration key we want to detect changes to
+   * @param singlePropertyChangeListener The callback handling to fire when the configuration changes.
    */
-  void onChange(String key, Consumer<String> callback);
+  void onChange(String key, Consumer<String> singlePropertyChangeListener);
 
   /**
    * Register a callback for a change to the given configuration key as an Int value.
+   * <p>
+   * Use this when we are only interested in changes to a single configuration property.
+   * If we are interested in multiple properties we should use {@link #onChange(Consumer, String...)}
    *
-   * @param key      The configuration key we want to detect changes to
-   * @param callback The callback handling to fire when the configuration changes.
+   * @param key                          The configuration key we want to detect changes to
+   * @param singlePropertyChangeListener The callback handling to fire when the configuration changes.
    */
-  void onChangeInt(String key, IntConsumer callback);
+  void onChangeInt(String key, IntConsumer singlePropertyChangeListener);
 
   /**
    * Register a callback for a change to the given configuration key as a Long value.
+   * <p>
+   * Use this when we are only interested in changes to a single configuration property.
+   * If we are interested in multiple properties we should use {@link #onChange(Consumer, String...)}
    *
-   * @param key      The configuration key we want to detect changes to
-   * @param callback The callback handling to fire when the configuration changes.
+   * @param key                          The configuration key we want to detect changes to
+   * @param singlePropertyChangeListener The callback handling to fire when the configuration changes.
    */
-  void onChangeLong(String key, LongConsumer callback);
+  void onChangeLong(String key, LongConsumer singlePropertyChangeListener);
 
   /**
    * Register a callback for a change to the given configuration key as a Boolean value.
+   * <p>
+   * Use this when we are only interested in changes to a single configuration property.
+   * If we are interested in multiple properties we should use {@link #onChange(Consumer, String...)}
    *
-   * @param key      The configuration key we want to detect changes to
-   * @param callback The callback handling to fire when the configuration changes.
+   * @param key                          The configuration key we want to detect changes to
+   * @param singlePropertyChangeListener The callback handling to fire when the configuration changes.
    */
-  void onChangeBool(String key, Consumer<Boolean> callback);
+  void onChangeBool(String key, Consumer<Boolean> singlePropertyChangeListener);
 
   /**
    * Put the loaded properties into System properties.

--- a/avaje-config/src/main/java/io/avaje/config/Configuration.java
+++ b/avaje-config/src/main/java/io/avaje/config/Configuration.java
@@ -324,14 +324,11 @@ public interface Configuration {
    * Register an event listener that will be notified of configuration changes.
    * <p>
    * If we are only interested in changes to a single property it is easier to use
-   * {@link #onChange(String, Consumer)} or the variants for int, long, boolean.
+   * {@link #onChange(String, Consumer)} or the variants for int, long, boolean
+   * onChangeInt(), onChangeLong(), onChangeBool().
    * <p>
    * Typically, we use this when we are interested in changes to multiple properties
    * and want to get and act on the values of multiple properties.
-   * <p>
-   * Events are created when configuration is changed via {@link #eventBuilder(String)},
-   * {@link #setProperty(String, String)}, {@link #clearProperty(String)} or when
-   * configuration is reloaded from its sources (e.g. watching file changes).
    *
    * <pre>{@code
    *  configuration.onChange((modificationEvent) -> {
@@ -373,14 +370,11 @@ public interface Configuration {
    *
    * <pre>{@code
    *
-   *   AtomicReference<String> value = new AtomicReference<>("initial");
+   *   configuration.onChange("myKey", (neValue) -> {
    *
-   *   configuration.onChange("myKey", (newStringValue) -> {
-   *     value.set(newStringValue);
+   *     // do something with the newValue ...
+   *
    *   ));
-   *
-   *   // using a method reference
-   *   configuration.onChange("myKey", value::set);
    *
    * }</pre>
    *

--- a/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
@@ -54,6 +54,9 @@ final class CoreConfiguration implements Configuration {
     this.pathPrefix = prefix;
   }
 
+  /**
+   * For testing purposes.
+   */
   CoreConfiguration(CoreEntry.CoreMap entries) {
     this(new ForegroundEventRunner(), new DefaultConfigurationLog(), entries, "");
   }


### PR DESCRIPTION
These examples are telling us that we should not deprecate the existing onChange single property methods, as using the new onChange ModificationEvent is a lot less intuitive for the 'single property change' use case.