### PR TITLE
Add inject 9.0 property plugin and getNullable

### DIFF
--- a/avaje-config/pom.xml
+++ b/avaje-config/pom.xml
@@ -37,6 +37,14 @@
       <version>1.0</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-inject</artifactId>
+      <version>9.0</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+
     <!-- If snakeyaml detected it will be used rather than built in simple parser -->
     <dependency>
       <groupId>org.yaml</groupId>
@@ -58,13 +66,6 @@
       <version>1.2.11</version>
       <scope>test</scope>
     </dependency>
-
-<!--    <dependency>-->
-<!--      <groupId>io.avaje</groupId>-->
-<!--      <artifactId>avaje-slf4j-jpl</artifactId>-->
-<!--      <version>1.1</version>-->
-<!--      <scope>test</scope>-->
-<!--    </dependency>-->
 
     <dependency>
       <groupId>io.avaje</groupId>

--- a/avaje-config/src/main/java/io/avaje/config/Config.java
+++ b/avaje-config/src/main/java/io/avaje/config/Config.java
@@ -1,16 +1,16 @@
 package io.avaje.config;
 
-import io.avaje.lang.NonNullApi;
-
 import java.math.BigDecimal;
 import java.net.URI;
-import java.net.URL;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 import java.util.function.LongConsumer;
+
+import io.avaje.lang.NonNullApi;
+import io.avaje.lang.Nullable;
 
 /**
  * Provides application Configuration based on loading properties and yaml files
@@ -98,6 +98,16 @@ public class Config {
    */
   public static String get(String key) {
     return data.get(key);
+  }
+
+  /**
+   * Return a required configuration value as String.
+   * @param key The configuration key
+   * @return The configured value or null if not set
+   */
+  @Nullable
+  public static String getNullable(String key) {
+    return data.getNullable(key);
   }
 
   /**

--- a/avaje-config/src/main/java/io/avaje/config/Configuration.java
+++ b/avaje-config/src/main/java/io/avaje/config/Configuration.java
@@ -1,6 +1,7 @@
 package io.avaje.config;
 
 import io.avaje.lang.NonNullApi;
+import io.avaje.lang.Nullable;
 
 import java.math.BigDecimal;
 import java.net.URI;
@@ -67,6 +68,15 @@ public interface Configuration {
    * @return The configured value
    */
   String get(String key);
+  
+
+  /**
+   * Return a required configuration value as String.
+   * @param key The configuration key
+   * @return The configured value or null if not set
+   */
+  @Nullable
+  String getNullable(String key);
 
   /**
    * Return a configuration string value with a given default.

--- a/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
@@ -5,9 +5,7 @@ import io.avaje.lang.Nullable;
 
 import java.lang.System.Logger.Level;
 import java.math.BigDecimal;
-import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -202,7 +200,13 @@ final class CoreConfiguration implements Configuration {
   public String get(String key) {
     return required(key);
   }
-
+  
+  @Override
+  @Nullable
+  public String getNullable(String key) {
+    return value(key);
+  }
+  
   @Override
   public String get(String key, String defaultValue) {
     requireNonNull(key, "key is required");

--- a/avaje-config/src/main/java/io/avaje/config/InjectPropertiesPlugin.java
+++ b/avaje-config/src/main/java/io/avaje/config/InjectPropertiesPlugin.java
@@ -1,0 +1,26 @@
+package io.avaje.config;
+
+import io.avaje.inject.spi.PropertyRequiresPlugin;
+
+public class InjectPropertiesPlugin implements PropertyRequiresPlugin {
+
+  @Override
+  public boolean contains(String property) {
+    return Config.getNullable(property) != null;
+  }
+
+  @Override
+  public boolean missing(String property) {
+    return Config.getNullable(property) == null;
+  }
+
+  @Override
+  public boolean equalTo(String property, String value) {
+    return value.equals(Config.getNullable(property));
+  }
+
+  @Override
+  public boolean notEqualTo(String property, String value) {
+    return !value.equals(Config.getNullable(property));
+  }
+}

--- a/avaje-config/src/main/java/module-info.java
+++ b/avaje-config/src/main/java/module-info.java
@@ -5,6 +5,7 @@ module io.avaje.config {
   requires transitive io.avaje.lang;
   requires transitive io.avaje.applog;
   requires static org.yaml.snakeyaml;
+  requires static io.avaje.inject;
 
   uses io.avaje.config.ConfigurationLog;
   uses io.avaje.config.ModificationEventRunner;

--- a/avaje-config/src/main/resources/META-INF/services/io.avaje.inject.spi.PropertyRequiresPlugin
+++ b/avaje-config/src/main/resources/META-INF/services/io.avaje.inject.spi.PropertyRequiresPlugin
@@ -1,1 +1,1 @@
-org.example.myapp.ConfigPropertiesPlugin
+io.avaje.config.InjectPropertiesPlugin

--- a/avaje-config/src/main/resources/META-INF/services/io.avaje.inject.spi.PropertyRequiresPlugin
+++ b/avaje-config/src/main/resources/META-INF/services/io.avaje.inject.spi.PropertyRequiresPlugin
@@ -1,0 +1,1 @@
+org.example.myapp.ConfigPropertiesPlugin


### PR DESCRIPTION
Kinda relies on 9 being deployed though.

- adds the new inject spi for property requires
- adds getNullable methods for less allocation of Optionals