### PR TITLE
Use avaje-inject 9.0-RC1 + javadoc + module-info provides

### DIFF
--- a/avaje-config/pom.xml
+++ b/avaje-config/pom.xml
@@ -18,7 +18,7 @@
   </scm>
 
   <properties>
-    <snakeyaml.version>1.32</snakeyaml.version>
+    <snakeyaml.version>2.0</snakeyaml.version>
     <nexus.staging.autoReleaseAfterClose>true</nexus.staging.autoReleaseAfterClose>
     <surefire.useModulePath>false</surefire.useModulePath>
   </properties>

--- a/avaje-config/pom.xml
+++ b/avaje-config/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-inject</artifactId>
-      <version>9.0</version>
+      <version>9.0-RC1</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>

--- a/avaje-config/src/main/java/io/avaje/config/Config.java
+++ b/avaje-config/src/main/java/io/avaje/config/Config.java
@@ -101,16 +101,6 @@ public class Config {
   }
 
   /**
-   * Return a required configuration value as String.
-   * @param key The configuration key
-   * @return The configured value or null if not set
-   */
-  @Nullable
-  public static String getNullable(String key) {
-    return data.getNullable(key);
-  }
-
-  /**
    * Return a configuration string value with a given default.
    *
    * @param key          The configuration key
@@ -129,6 +119,20 @@ public class Config {
    */
   public static Optional<String> getOptional(String key) {
     return data.getOptional(key);
+  }
+
+  /**
+   * Return a configuration value as String or null if it is not defined.
+   * <p>
+   * This is an alternative to {@link #getOptional(String)} for cases where
+   * we prefer to work with null values rather than Optional.
+   *
+   * @param key The configuration key
+   * @return The configured value or null if not set
+   */
+  @Nullable
+  public static String getNullable(String key) {
+    return data.getNullable(key);
   }
 
   /**

--- a/avaje-config/src/main/java/io/avaje/config/Configuration.java
+++ b/avaje-config/src/main/java/io/avaje/config/Configuration.java
@@ -68,15 +68,6 @@ public interface Configuration {
    * @return The configured value
    */
   String get(String key);
-  
-
-  /**
-   * Return a required configuration value as String.
-   * @param key The configuration key
-   * @return The configured value or null if not set
-   */
-  @Nullable
-  String getNullable(String key);
 
   /**
    * Return a configuration string value with a given default.
@@ -94,6 +85,18 @@ public interface Configuration {
    * @return The configured value wrapped as optional
    */
   Optional<String> getOptional(String key);
+
+  /**
+   * Return a configuration value as String or null if it is not defined.
+   * <p>
+   * This is an alternative to {@link #getOptional(String)} for cases where
+   * we prefer to work with null values rather than Optional.
+   *
+   * @param key The configuration key
+   * @return The configured value or null if not set
+   */
+  @Nullable
+  String getNullable(String key);
 
   /**
    * Return a required boolean configuration value.

--- a/avaje-config/src/main/java/io/avaje/config/InjectPropertiesPlugin.java
+++ b/avaje-config/src/main/java/io/avaje/config/InjectPropertiesPlugin.java
@@ -2,6 +2,10 @@ package io.avaje.config;
 
 import io.avaje.inject.spi.PropertyRequiresPlugin;
 
+/**
+ * Plugin used with Avaje Inject to support the {@code @RequiresProperty} annotation
+ * for conditional wiring based on properties.
+ */
 public class InjectPropertiesPlugin implements PropertyRequiresPlugin {
 
   @Override

--- a/avaje-config/src/main/java/module-info.java
+++ b/avaje-config/src/main/java/module-info.java
@@ -10,4 +10,6 @@ module io.avaje.config {
   uses io.avaje.config.ConfigurationLog;
   uses io.avaje.config.ModificationEventRunner;
   uses io.avaje.config.ConfigurationSource;
+
+  provides io.avaje.inject.spi.PropertyRequiresPlugin with io.avaje.config.InjectPropertiesPlugin;
 }


### PR DESCRIPTION
- Use avaje-inject 9.0-RC1
- Add our module-info provides for module-path
- Moves the getNullable() methods to below the getOptional() and add a bit more javadoc. Maybe reduce the ire some people will feel for a getNullable()