### PR TITLE
For default reading of ENV variables include more typically key

### DIFF
--- a/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
@@ -438,6 +438,10 @@ final class CoreConfiguration implements Configuration {
     }
   }
 
+  static String toEnvKey(String key) {
+    return key.replace('.','_').toUpperCase();
+  }
+
   private static class ModifyAwareProperties {
 
     private final CoreEntry.CoreMap entries;
@@ -505,8 +509,8 @@ final class CoreConfiguration implements Configuration {
 
     @Nullable
     private static String systemValue(String key) {
-      final String systemValue = System.getProperty(key);
-      return systemValue == null ? System.getenv(key) : systemValue;
+      final String val = System.getProperty(key, System.getenv(key));
+      return val != null ? val : System.getenv(toEnvKey(key));
     }
 
     void loadIntoSystemProperties(Set<String> excludedSet) {

--- a/avaje-config/src/test/java/io/avaje/config/CoreConfigurationTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/CoreConfigurationTest.java
@@ -120,6 +120,14 @@ class CoreConfigurationTest {
   }
 
   @Test
+  void toEnvKey() {
+    assertThat(CoreConfiguration.toEnvKey("My")).isEqualTo("MY");
+    assertThat(CoreConfiguration.toEnvKey("My.Foo")).isEqualTo("MY_FOO");
+    assertThat(CoreConfiguration.toEnvKey("my.foo.bar")).isEqualTo("MY_FOO_BAR");
+    assertThat(CoreConfiguration.toEnvKey("BAR")).isEqualTo("BAR");
+  }
+
+  @Test
   void get() {
     assertEquals(data.get("a", "something"), "1");
     assertEquals(data.get("doesNotExist", "something"), "something");
@@ -166,7 +174,7 @@ class CoreConfigurationTest {
     assertThat(data.getDecimal("myTestDecimal", "10.4")).isEqualByComparingTo("14.3");
     data.clearProperty("myTestDecimal");
   }
-  
+
   @Test
   void getList() {
     assertThat(data.list().of("someValues")).contains("13", "42", "55");


### PR DESCRIPTION
System property names are often lowercase with periods. ENV variable names are often Uppercase with underscores.

Enhance the default values lookup of ENV variables to include the key AS IS and also the key modified like: key.replace('.','_').toUpperCase()