### PR TITLE
Multi-Profile Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ Config.onChangeBool("myapp.foo", newBooleanValue -> {
 
 ```
 
-
 ## Loading properties
 
 Config loads properties from expected locations as well as via command line arguments.
@@ -77,11 +76,17 @@ Below is the how it looks for configuration properties.
 
 - loads via system property `props.file` or environment variable `PROPS_FILE` (if defined)
 
+- loads via system property `config.profiles` or environment variable `CONFIG_PROFILES` (if defined).
+
+Setting the `config.profiles` or environment variable `CONFIG_PROFILES` will cause avaje config to load the property files in the form `application-${profile}.properties` (will also work for yml/yaml files). 
+
+For example, if you set the `config.profiles` to `dev,docker` it will attempt to load `application-dev.properties` and `application-docker.properties`.
+
 - loads via `load.properties` property.
 
 We can define a `load.properties` property which has name of property file in resource folder, or path locations for other properties/yaml files to load.
 
-`load.properties` is pretty versatile and can even be chained. For example, in your main application properties, you can have `load.properties=application-${profile:local}.properties` to load based on the profile environment variable/-Dprofile JVM arg, and in the loaded properties you can add `load.properties` there to load more properties and so on.
+`load.properties` is pretty versatile and can even be chained. For example, in your main application properties, you can have `load.properties=application-${profile:local}.properties` to load based on another property, and in the loaded properties you can add `load.properties` there to load more properties, and so on.
 
 Example application.properties:
 ```

--- a/avaje-config/src/main/java/io/avaje/config/InitialLoadContext.java
+++ b/avaje-config/src/main/java/io/avaje/config/InitialLoadContext.java
@@ -58,6 +58,7 @@ final class InitialLoadContext {
     initSystemProperty(System.getenv("POD_NAMESPACE"), "app.environment");
     initSystemProperty(System.getenv("POD_VERSION"), "app.version");
     initSystemProperty(System.getenv("POD_IP"), "app.ipAddress");
+    initSystemProperty(System.getenv("CONFIG_PROFILES"), "config.profiles");
   }
 
   private void initSystemProperty(String envValue, String key) {
@@ -139,6 +140,13 @@ final class InitialLoadContext {
       indirectLocation = map.get("load.properties.override");
     }
     return indirectLocation == null ? null : indirectLocation.value();
+  }
+
+  String profiles() {
+    final CoreEntry indirectLocation = map.get("config.profiles");
+    return indirectLocation == null
+        ? System.getProperty("config.profiles")
+        : indirectLocation.value();
   }
 
   /**

--- a/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
+++ b/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
@@ -211,9 +211,9 @@ final class InitialLoader {
     if (paths != null) {
       for (final String path : splitPaths(paths)) {
         final var profile = loadContext.eval(path);
-        loadProperties("application-" + profile + ".properties", RESOURCE);
-        loadYaml("application-" + profile + ".yaml", RESOURCE);
-        loadYaml("application-" + profile + ".yml", RESOURCE);
+        loadWithExtensionCheck("application-" + profile + ".properties");
+        loadWithExtensionCheck("application-" + profile + ".yaml");
+        loadWithExtensionCheck("application-" + profile + ".yml");
       }
     }
   }

--- a/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
+++ b/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
@@ -204,6 +204,19 @@ final class InitialLoader {
     }
   }
 
+  /** Load configuration defined by a <em>config.profiles</em> property. */
+  private void loadViaProfiles() {
+    final String paths = loadContext.profiles();
+    if (paths != null) {
+      for (final String path : splitPaths(paths)) {
+        final var profile = loadContext.eval(path);
+        loadProperties("application-" + profile + ".properties", RESOURCE);
+        loadYaml("application-" + profile + ".yaml", RESOURCE);
+        loadYaml("application-" + profile + ".yml", RESOURCE);
+      }
+    }
+  }
+
   private void loadViaPaths(String paths) {
     for (String path : splitPaths(paths)) {
       loadWithExtensionCheck(loadContext.eval(path));

--- a/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
+++ b/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
@@ -118,6 +118,7 @@ final class InitialLoader {
     loadMain(FILE);
     loadViaSystemProperty();
     loadViaIndirection();
+    loadViaProfiles();
     // test configuration (if found) overrides main configuration
     // we should only find these resources when running tests
     if (!loadTest()) {


### PR DESCRIPTION
Now can set the profiles and load multiple files based on that.

it can be done in three ways

1. Setting a `CONFIG_PROFILES` env variable
2. Adding a `-Dconfig.profiles` to the command-line
3. Having a `config.profiles` property in a config file

Fixes #79 