### PR TITLE
#81 Adjust load ordering of profiles (take2)

### DIFF
--- a/avaje-config/src/test/java/io/avaje/config/InitialLoaderTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/InitialLoaderTest.java
@@ -19,10 +19,10 @@ class InitialLoaderTest {
 
     InitialLoader loader = newInitialLoader();
     loader.loadProperties("test-properties/application.properties", RESOURCE);
-    loader.loadYaml("test-properties/application.yaml", RESOURCE);
+    loader.loadYamlPath("test-properties/application.yaml", RESOURCE);
 
     loader.loadProperties("test-properties/one.properties", RESOURCE);
-    loader.loadYaml("test-properties/foo.yml", RESOURCE);
+    loader.loadYamlPath("test-properties/foo.yml", RESOURCE);
 
     var properties = loader.eval();
 
@@ -53,7 +53,7 @@ class InitialLoaderTest {
   @Test
   void loadYaml() {
     InitialLoader loader = newInitialLoader();
-    loader.loadYaml("test-properties/foo.yml", RESOURCE);
+    loader.loadYamlPath("test-properties/foo.yml", RESOURCE);
     var properties = loader.eval();
 
     assertThat(properties.get("Some.Other.pass").value()).isEqualTo("someDefault");


### PR DESCRIPTION
This change ensures that for any additional profiles defined in loadMain() the RESOURCE is loaded.

- Keeps a track of the profile resources loaded
- Ensures for any additional profiles defined via loadMain() that those RESOURCE are also loaded

Background:
Config generally loads RESOURCE source first, and FILE source later. This allows the FILE source properties to override the RESOURCE source properties in a predictable manner.