### PR TITLE
Fix where load by props or command line args or indirection does not load FILE if RESOURCE found

### DIFF
--- a/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
+++ b/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
@@ -268,9 +268,9 @@ final class InitialLoader {
 
   boolean loadWithExtensionCheck(String fileName) {
     if (fileName.endsWith("yaml") || fileName.endsWith("yml")) {
-      return loadYamlPath(fileName, RESOURCE) || loadYamlPath(fileName, FILE);
+      return loadYamlPath(fileName, RESOURCE) | loadYamlPath(fileName, FILE);
     } else if (fileName.endsWith("properties")) {
-      return loadProperties(fileName, RESOURCE) || loadProperties(fileName, FILE);
+      return loadProperties(fileName, RESOURCE) | loadProperties(fileName, FILE);
     } else {
       throw new IllegalArgumentException("Expecting only yaml or properties file but got [" + fileName + "]");
     }

--- a/avaje-config/src/test/java/io/avaje/config/InitialLoaderTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/InitialLoaderTest.java
@@ -48,6 +48,7 @@ class InitialLoaderTest {
     assertThat(properties.get("dummy.yaml.bar").value()).isEqualTo("baz");
     assertThat(properties.get("dummy.yml.foo").value()).isEqualTo("bar");
     assertThat(properties.get("dummy.properties.foo").value()).isEqualTo("bar");
+    assertThat(properties.get("dummy.properties.a").value()).isEqualTo("fromResource");
   }
 
   @Test

--- a/avaje-config/src/test/resources/test-dummy.properties
+++ b/avaje-config/src/test/resources/test-dummy.properties
@@ -1,0 +1,2 @@
+dummy.properties.a=fromResource
+dummy.properties.foo=bazz


### PR DESCRIPTION
These 3 load options call through to loadWithExtensionCheck() and that was NOT going to load FILE if the RESOURCE had been found. Generally this is not an issue as these load options generally are not used with BOTH a RESOURCE and FILE properties source.

However, this changes loadWithExtensionCheck() such that it will always try to load FILE source even if a RESOURCE source was found. The thinking here is that FILE source is externally configured and when provided is expected to override any default properties defined in RESOURCE sources which come with the application - in this sense it means config should always load a FILE source if there is one.