### PR TITLE
Add Configuration.Builder for manual construction

### DIFF
--- a/avaje-config/src/main/java/io/avaje/config/Config.java
+++ b/avaje-config/src/main/java/io/avaje/config/Config.java
@@ -30,7 +30,7 @@ import io.avaje.lang.Nullable;
  *
  *  String topicName = Config.get("app.topic.name");
  *
- *  List<Integer> codes = Config.getList().ofInt("my.codes", 42, 54);
+ *  List<Integer> codes = Config.list().ofInt("my.codes", 42, 54);
  *
  * }</pre>
  */

--- a/avaje-config/src/main/java/io/avaje/config/Configuration.java
+++ b/avaje-config/src/main/java/io/avaje/config/Configuration.java
@@ -632,4 +632,54 @@ public interface Configuration {
      */
     <T> Set<T> ofType(String key, Function<String, T> mappingFunction);
   }
+
+  /**
+   * Return a Builder for Configuration that is loaded manually (not via the normal resource loading).
+   */
+  static Builder builder() {
+    return new CoreConfigurationBuilder();
+  }
+
+  /**
+   * Build Configuration manually explicitly loading all the configuration as key value pairs.
+   * <p>
+   * Building configuration this way does NOT automatically load resources like application.properties
+   * and also does NOT load ConfigurationSource. ALL configuration is explicitly loaded via calls
+   * to {@link Builder#put(String, String)}, {@link Builder#putAll(Map)}.
+   */
+  interface Builder {
+
+    /**
+     * Put an entry into the configuration.
+     */
+    Builder put(String key, String value);
+
+    /**
+     * Put entries into the configuration.
+     */
+    Builder putAll(Map<String, ?> sourceMap);
+
+    /**
+     * Put entries into the configuration from properties.
+     */
+    Builder putAll(Properties source);
+
+    /**
+     * Optionally set the event runner to use . If not specified a foreground runner will be used.
+     */
+    Builder eventRunner(ModificationEventRunner eventRunner);
+
+    /**
+     * Optionally set the log to use. If not specified then a logger using System.Logger will be used.
+     */
+    Builder log(ConfigurationLog log);
+
+    /**
+     * Build and return the Configuration.
+     * <p>
+     * Performs evaluation of property values that contain expressions (e.g. {@code ${user.home}})
+     * and returns the configuration.
+     */
+    Configuration build();
+  }
 }

--- a/avaje-config/src/main/java/io/avaje/config/Configuration.java
+++ b/avaje-config/src/main/java/io/avaje/config/Configuration.java
@@ -675,6 +675,11 @@ public interface Configuration {
     Builder log(ConfigurationLog log);
 
     /**
+     * Optionally set the resource loader to use. If not specified then class path based resource loader is used.
+     */
+    Builder resourceLoader(ResourceLoader resourceLoader);
+
+    /**
      * Build and return the Configuration.
      * <p>
      * Performs evaluation of property values that contain expressions (e.g. {@code ${user.home}})

--- a/avaje-config/src/main/java/io/avaje/config/Configuration.java
+++ b/avaje-config/src/main/java/io/avaje/config/Configuration.java
@@ -26,7 +26,7 @@ import io.avaje.lang.Nullable;
  *
  *  String topicName = Config.get("app.topic.name");
  *
- *  List<Integer> codes = Config.getList().ofInt("my.codes", 42, 54);
+ *  List<Integer> codes = Config.list().ofInt("my.codes", 42, 54);
  *
  * }</pre>
  */
@@ -286,7 +286,7 @@ public interface Configuration {
    *
    * <pre>{@code
    *
-   *  List<Integer> codes = Config.getList().ofInt("my.codes", 97, 45);
+   *  List<Integer> codes = Config.list().ofInt("my.codes", 97, 45);
    *
    * }</pre>
    */
@@ -485,7 +485,7 @@ public interface Configuration {
    * <h3>Example</h3>
    * <pre>{@code
    *
-   *  List<Integer> codes = Config.getList().ofInt("my.codes", 42, 54);
+   *  List<Integer> codes = Config.list().ofInt("my.codes", 42, 54);
    *
    * }</pre>
    */
@@ -678,6 +678,13 @@ public interface Configuration {
      * Optionally set the resource loader to use. If not specified then class path based resource loader is used.
      */
     Builder resourceLoader(ResourceLoader resourceLoader);
+
+    /**
+     * Specify to include standard resource loading.
+     * <p>
+     * This includes the loading of application.properties, application.yaml etc.
+     */
+    Builder includeResourceLoading();
 
     /**
      * Build and return the Configuration.

--- a/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
@@ -64,19 +64,14 @@ final class CoreConfiguration implements Configuration {
    * Initialise the configuration which loads all the property sources.
    */
   static Configuration initialise() {
-    final var runner = ServiceLoader.load(ModificationEventRunner.class).findFirst().orElseGet(ForegroundEventRunner::new);
-    final var log = ServiceLoader.load(ConfigurationLog.class).findFirst().orElseGet(DefaultConfigurationLog::new);
-    log.preInitialisation();
-    final var resourceLoader = ServiceLoader.load(ResourceLoader.class).findFirst().orElseGet(DefaultResourceLoader::new);
-    final var loader = new InitialLoader(log, resourceLoader);
-    return new CoreConfiguration(runner, log, loader.load()).postLoad(loader);
+    return new CoreConfigurationBuilder().loadResources();
   }
 
   CoreConfiguration postLoad() {
     return postLoad(null);
   }
 
-  private CoreConfiguration postLoad(@Nullable InitialLoader loader) {
+  CoreConfiguration postLoad(@Nullable InitialLoader loader) {
     if (loader != null) {
       loadSources(loader.loadedFrom());
       loader.initWatcher(this);

--- a/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
@@ -69,13 +69,24 @@ final class CoreConfiguration implements Configuration {
     log.preInitialisation();
     final var resourceLoader = ServiceLoader.load(ResourceLoader.class).findFirst().orElseGet(DefaultResourceLoader::new);
     final var loader = new InitialLoader(log, resourceLoader);
-    final CoreConfiguration configuration = new CoreConfiguration(runner, log, loader.load());
-    configuration.loadSources(loader.loadedFrom());
-    loader.initWatcher(configuration);
-    configuration.initSystemProperties();
-    configuration.logMessage(loader);
+    return new CoreConfiguration(runner, log, loader.load()).postLoad(loader);
+  }
+
+  CoreConfiguration postLoad() {
+    return postLoad(null);
+  }
+
+  private CoreConfiguration postLoad(@Nullable InitialLoader loader) {
+    if (loader != null) {
+      loadSources(loader.loadedFrom());
+      loader.initWatcher(this);
+    }
+    initSystemProperties();
+    if (loader != null) {
+      logMessage(loader);
+    }
     log.postInitialisation();
-    return configuration;
+    return this;
   }
 
   ConfigurationLog log() {

--- a/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
@@ -64,11 +64,9 @@ final class CoreConfiguration implements Configuration {
    * Initialise the configuration which loads all the property sources.
    */
   static Configuration initialise() {
-    return new CoreConfigurationBuilder().loadResources();
-  }
-
-  CoreConfiguration postLoad() {
-    return postLoad(null);
+    return new CoreConfigurationBuilder()
+      .includeResourceLoading()
+      .build();
   }
 
   CoreConfiguration postLoad(@Nullable InitialLoader loader) {

--- a/avaje-config/src/main/java/io/avaje/config/CoreConfigurationBuilder.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreConfigurationBuilder.java
@@ -1,0 +1,89 @@
+package io.avaje.config;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.ServiceLoader;
+
+import static java.util.Objects.requireNonNull;
+
+final class CoreConfigurationBuilder implements Configuration.Builder {
+
+  private final Map<String, String> sourceMap = new LinkedHashMap<>();
+  private ModificationEventRunner eventRunner;
+  private ConfigurationLog configurationLog;
+
+  @Override
+  public Configuration.Builder eventRunner(ModificationEventRunner eventRunner) {
+    this.eventRunner = eventRunner;
+    return this;
+  }
+
+  @Override
+  public Configuration.Builder log(ConfigurationLog configurationLog) {
+    this.configurationLog = configurationLog;
+    return this;
+  }
+
+  @Override
+  public Configuration.Builder put(String key, String value) {
+    requireNonNull(key);
+    requireNonNull(value);
+    sourceMap.put(key, value);
+    return this;
+  }
+
+  @Override
+  public Configuration.Builder putAll(Map<String, ?> source) {
+    requireNonNull(source);
+    source.forEach((key, value) -> {
+      if (key != null && value != null) {
+        put(key, value.toString());
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public Configuration.Builder putAll(Properties source) {
+    requireNonNull(source);
+    source.forEach((key, value) -> {
+      if (key != null && value != null) {
+        put(key.toString(), value.toString());
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public Configuration build() {
+    return new CoreConfiguration(initRunner(), initLog(), initEntries())
+      .postLoad();
+  }
+
+  private CoreEntry.CoreMap initEntries() {
+    final var entries = CoreEntry.newMap();
+    sourceMap.forEach((key, value) -> entries.put(key, value, "initial"));
+    return CoreExpressionEval.evalFor(entries);
+  }
+
+  private ConfigurationLog initLog() {
+    if (configurationLog != null) {
+      return configurationLog;
+    } else {
+      return ServiceLoader.load(ConfigurationLog.class)
+        .findFirst()
+        .orElseGet(DefaultConfigurationLog::new);
+    }
+  }
+
+  private ModificationEventRunner initRunner() {
+    if (eventRunner != null) {
+      return eventRunner;
+    } else {
+      return ServiceLoader.load(ModificationEventRunner.class)
+        .findFirst()
+        .orElseGet(CoreConfiguration.ForegroundEventRunner::new);
+    }
+  }
+}

--- a/avaje-config/src/main/java/io/avaje/config/InitialLoadContext.java
+++ b/avaje-config/src/main/java/io/avaje/config/InitialLoadContext.java
@@ -125,9 +125,9 @@ final class InitialLoadContext {
   /**
    * Evaluate all the expressions and return as a Properties object.
    */
-  CoreMap evalAll() {
+  CoreMap entryMap() {
     log.log(Level.TRACE, "load from {0}", loadedResources);
-    return CoreExpressionEval.evalFor(map);
+    return map;
   }
 
   /**

--- a/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
+++ b/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
@@ -88,7 +88,7 @@ final class InitialLoader {
   CoreMap load() {
     loadEnvironmentVars();
     loadLocalFiles();
-    return eval();
+    return entryMap();
   }
 
   void initWatcher(CoreConfiguration configuration) {
@@ -279,8 +279,8 @@ final class InitialLoader {
   /**
    * Evaluate all the configuration entries and return as properties.
    */
-  CoreMap eval() {
-    return loadContext.evalAll();
+  CoreMap entryMap() {
+    return loadContext.entryMap();
   }
 
   /**

--- a/avaje-config/src/test/java/io/avaje/config/CoreConfigurationTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/CoreConfigurationTest.java
@@ -134,7 +134,7 @@ class CoreConfigurationTest {
       .put("myExtraOne", "baz")
       .build();
 
-    assertEquals(conf.get("a", "something"), "1");
+    assertEquals(conf.get("a"), "1");
     assertEquals(conf.get("doesNotExist", "something"), "something");
     assertEquals(conf.get("myExtraMap"), "foo");
     assertEquals(conf.get("myExtraMap.b"), "bar");
@@ -142,6 +142,24 @@ class CoreConfigurationTest {
 
     String userHome = System.getProperty("user.home");
     assertEquals(conf.get("myHome"), "my/" + userHome + "/home");
+  }
+
+  @Test
+  void builder_withResources() {
+    var conf = Configuration.builder()
+      .putAll(properties())
+      .putAll(Map.of("myExtraMap", "foo", "myExtraMap.b", "bar"))
+      .put("myExtraOne", "baz")
+      .includeResourceLoading()
+      .build();
+
+    // loaded from application-test.yaml
+    assertThat(conf.get("myapp.activateFoo")).isEqualTo("true");
+    // loaded explicitly
+    assertThat(conf.get("a")).isEqualTo( "1");
+
+    String userHome = System.getProperty("user.home");
+    assertThat(conf.get("myHome")).isEqualTo("my/" + userHome + "/home");
   }
 
   @Test

--- a/avaje-config/src/test/java/io/avaje/config/InitialLoaderTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/InitialLoaderTest.java
@@ -2,6 +2,7 @@ package io.avaje.config;
 
 import org.junit.jupiter.api.Test;
 
+import static io.avaje.config.CoreExpressionEval.evalFor;
 import static io.avaje.config.InitialLoader.Source.RESOURCE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -24,7 +25,7 @@ class InitialLoaderTest {
     loader.loadProperties("test-properties/one.properties", RESOURCE);
     loader.loadYamlPath("test-properties/foo.yml", RESOURCE);
 
-    var properties = loader.eval();
+    var properties = evalFor(loader.entryMap());
 
     assertEquals("fromProperties", properties.get("app.fromProperties").value());
     assertEquals("Two", properties.get("app.two").value());
@@ -44,7 +45,7 @@ class InitialLoaderTest {
     loader.loadWithExtensionCheck("test-dummy.yml");
     loader.loadWithExtensionCheck("test-dummy2.yaml");
 
-    var properties = loader.eval();
+    var properties = evalFor(loader.entryMap());
     assertThat(properties.get("dummy.yaml.bar").value()).isEqualTo("baz");
     assertThat(properties.get("dummy.yml.foo").value()).isEqualTo("bar");
     assertThat(properties.get("dummy.properties.foo").value()).isEqualTo("bar");
@@ -55,7 +56,7 @@ class InitialLoaderTest {
   void loadYaml() {
     InitialLoader loader = newInitialLoader();
     loader.loadYamlPath("test-properties/foo.yml", RESOURCE);
-    var properties = loader.eval();
+    var properties = evalFor(loader.entryMap());
 
     assertThat(properties.get("Some.Other.pass").value()).isEqualTo("someDefault");
   }
@@ -67,7 +68,7 @@ class InitialLoaderTest {
 
     InitialLoader loader = newInitialLoader();
     loader.loadProperties("test-properties/one.properties", RESOURCE);
-    var properties = loader.eval();
+    var properties = evalFor(loader.entryMap());
 
     assertThat(properties.get("hello").source()).isEqualTo("resource:test-properties/one.properties");
     assertThat(properties.get("hello").value()).isEqualTo("there");
@@ -125,13 +126,13 @@ class InitialLoaderTest {
     try {
       System.setProperty("suppressTestResource", "");
       InitialLoader loader = newInitialLoader();
-      var properties = loader.load();
+      var properties = evalFor(loader.load());
       assertThat(properties.get("myapp.activateFoo").value()).isEqualTo("true");
 
       //application-test.yaml is not loaded when suppressTestResource is set to true
       System.setProperty("suppressTestResource", "true");
       InitialLoader loaderWithSuppressTestResource = newInitialLoader();
-      var propertiesWithoutTestResource = loaderWithSuppressTestResource.load();
+      var propertiesWithoutTestResource = evalFor(loaderWithSuppressTestResource.load());
       assertThat(propertiesWithoutTestResource.get("myapp.activateFoo")).isNull();
     } finally {
       System.clearProperty("suppressTestResource");


### PR DESCRIPTION
- Adds Configuration.Builder for manually creating a Configuration
- Refactor extract the internal CoreConfiguration.postLoad() logic

This is to support use of Configuration where the configuration source key/values is all controlled and explicitly populated.