### PR TITLE
Add automatic detection of ${docker.host}

### DIFF
--- a/avaje-config/src/main/java/io/avaje/config/CoreExpressionEval.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreExpressionEval.java
@@ -18,6 +18,7 @@ final class CoreExpressionEval implements Configuration.ExpressionEval {
    * Used to detect the end of an expression.
    */
   private static final String END = "}";
+  private static final String DOCKER_HOST = "docker.host";
 
   private CoreEntry.CoreMap sourceMap;
   private Properties sourceProperties;
@@ -148,6 +149,10 @@ final class CoreExpressionEval implements Configuration.ExpressionEval {
       } else {
         if (defaultValue != null) {
           buf.append(defaultValue);
+        } else if (DOCKER_HOST.equals(expression)) {
+          final String dockerHost = DockerHost.host();
+          buf.append(dockerHost);
+          System.setProperty("docker.host", dockerHost);
         } else {
           buf.append(START).append(expression).append(END);
         }

--- a/avaje-config/src/main/java/io/avaje/config/DockerHost.java
+++ b/avaje-config/src/main/java/io/avaje/config/DockerHost.java
@@ -1,0 +1,24 @@
+package io.avaje.config;
+
+import java.io.File;
+import java.util.Locale;
+
+/**
+ * Support automatic translation of ${docker.host} detecting Docker-In-Docker and OS.
+ */
+final class DockerHost {
+
+  static String host() {
+    return !dind() ? "localhost" : dockerInDockerHost();
+  }
+
+  private static boolean dind() {
+    return (new File("/.dockerenv")).exists();
+  }
+
+  private static String dockerInDockerHost() {
+    String os = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH);
+    return !os.contains("mac") && !os.contains("darwin") && !os.contains("win") ? "172.17.0.1" : "host.docker.internal";
+  }
+
+}

--- a/avaje-config/src/test/java/io/avaje/config/ConfigTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/ConfigTest.java
@@ -126,7 +126,7 @@ class ConfigTest {
     assertThat(System.getProperty("myapp.bar.barDouble")).isEqualTo("33.3");
 
     assertThat(properties).containsKeys("config.load.systemProperties", "config.watch.enabled", "myExternalLoader", "myapp.activateFoo", "myapp.bar.barDouble", "myapp.bar.barRules", "myapp.fooHome", "myapp.fooName", "system.excluded.properties");
-    assertThat(properties).hasSize(11);
+    assertThat(properties).hasSize(12);
   }
 
   @Test

--- a/avaje-config/src/test/java/io/avaje/config/ConfigTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/ConfigTest.java
@@ -7,6 +7,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -174,6 +175,15 @@ class ConfigTest {
   void get_withEval() {
     String home = System.getProperty("user.home");
     assertThat(Config.get("myapp.fooHome")).isEqualTo(home + "/config");
+  }
+
+  @Test
+  void get_dockerHost() {
+    Optional<String> dockerHost = Config.getOptional("myapp.testHost");
+    assertThat(dockerHost).isPresent();
+    String testHost = dockerHost.get();
+    assertThat(testHost).isNotEqualTo("${docker.host}");
+    assertThat(System.getProperty("docker.host")).isEqualTo(testHost);
   }
 
   @Test

--- a/avaje-config/src/test/resources/application-test.yaml
+++ b/avaje-config/src/test/resources/application-test.yaml
@@ -1,4 +1,5 @@
 myapp:
+  testHost: ${docker.host}
   activateFoo: true
   fooName: Hello
   fooHome: ${HOME}/config


### PR DESCRIPTION
Based on docker-in-docker and operating system detection.

Also sets as a system property via:
System.setProperty("docker.host", dockerHost);

The motivation for this is to assist testing / component testing when using docker containers and potentially running docker-in-docker (in CI builds). This logic is contributed from ebean-test-containers, adding it to avaje-config can help more generally.