### PR TITLE
Allow access to parsers from configuration

### DIFF
--- a/avaje-config/src/main/java/io/avaje/config/ConfigParser.java
+++ b/avaje-config/src/main/java/io/avaje/config/ConfigParser.java
@@ -1,6 +1,7 @@
 package io.avaje.config;
 
 import java.io.InputStream;
+import java.io.Reader;
 import java.util.Map;
 
 /**
@@ -14,9 +15,17 @@ public interface ConfigParser {
   String[] supportedExtensions();
 
   /**
-   * Loads a file into a flat map of key value pairs.
+   * Parse content into key value pairs.
    *
-   * @param is stream of file contents
+   * @param reader configuration contents
+   * @return Key-Value pairs of all the configs
+   */
+  Map<String, String> load(Reader reader);
+
+  /**
+   * Parse content into key value pairs.
+   *
+   * @param is configuration contents
    * @return Key-Value pairs of all the configs
    */
   Map<String, String> load(InputStream is);

--- a/avaje-config/src/main/java/io/avaje/config/Configuration.java
+++ b/avaje-config/src/main/java/io/avaje/config/Configuration.java
@@ -507,6 +507,24 @@ public interface Configuration {
   void evalModify(Properties properties);
 
   /**
+   * Return the parser for the given extension.
+   *
+   * <pre>{@code
+   *
+   *   // obtain a yaml parser
+   *   ConfigParser yamlParser = configuration.parser("yaml").orElseThrow();
+   *
+   *   // parse some yaml content
+   *   Map<String,String> keyValues = yamlParser.load(inputStream)
+   *
+   *   // put the keyValues into the configuration
+   *   configuration.putAll(keyValues);
+   *
+   * }</pre>
+   */
+  Optional<ConfigParser> parser(String extension);
+
+  /**
    * Expression evaluation.
    */
   interface ExpressionEval {

--- a/avaje-config/src/main/java/io/avaje/config/CoreConfigurationBuilder.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreConfigurationBuilder.java
@@ -75,11 +75,12 @@ final class CoreConfigurationBuilder implements Configuration.Builder {
   public Configuration build() {
     final var runner = initRunner();
     final var log = initLog();
+    final var parsers = new Parsers();
     if (includeResourceLoading) {
       log.preInitialisation();
-      initialLoader = new InitialLoader(log, initResourceLoader());
+      initialLoader = new InitialLoader(parsers, log, initResourceLoader());
     }
-    return new CoreConfiguration(runner, log, initEntries()).postLoad(initialLoader);
+    return new CoreConfiguration(parsers, runner, log, initEntries()).postLoad(initialLoader);
   }
 
   private CoreEntry.CoreMap initEntries() {

--- a/avaje-config/src/main/java/io/avaje/config/FileWatch.java
+++ b/avaje-config/src/main/java/io/avaje/config/FileWatch.java
@@ -20,7 +20,7 @@ final class FileWatch {
     this.log = configuration.log();
     this.configuration = configuration;
     this.delay = configuration.getLong("config.watch.delay", 60);
-    this.period = configuration.getInt("config.watch.period", 10);
+    this.period = configuration.getLong("config.watch.period", 10);
     this.parsers = parsers;
     this.files = initFiles(loadedFiles);
     if (files.isEmpty()) {

--- a/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
+++ b/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
@@ -41,10 +41,10 @@ final class InitialLoader {
   private final Set<String> profileResourceLoaded = new HashSet<>();
   private final Parsers parsers;
 
-  InitialLoader(ConfigurationLog log, ResourceLoader resourceLoader) {
+  InitialLoader(Parsers parsers, ConfigurationLog log, ResourceLoader resourceLoader) {
+    this.parsers = parsers;
     this.log = log;
     this.loadContext = new InitialLoadContext(log, resourceLoader);
-    this.parsers = new Parsers();
   }
 
   Set<String> loadedFrom() {

--- a/avaje-config/src/main/java/io/avaje/config/YamlLoaderSimple.java
+++ b/avaje-config/src/main/java/io/avaje/config/YamlLoaderSimple.java
@@ -9,6 +9,11 @@ import java.util.*;
 final class YamlLoaderSimple implements YamlLoader {
 
   @Override
+  public Map<String, String> load(Reader reader) {
+    return new Load().load(reader);
+  }
+
+  @Override
   public Map<String, String> load(InputStream is) {
     return new Load().load(is);
   }
@@ -39,7 +44,11 @@ final class YamlLoaderSimple implements YamlLoader {
     private int multiLineIndent;
 
     private Map<String, String> load(InputStream is) {
-      try (LineNumberReader lineReader = new LineNumberReader(new InputStreamReader(is))) {
+      return load(new InputStreamReader(is));
+    }
+
+    private Map<String, String> load(Reader reader) {
+      try (LineNumberReader lineReader = new LineNumberReader(reader)) {
         String line;
         do {
           line = lineReader.readLine();

--- a/avaje-config/src/main/java/io/avaje/config/YamlLoaderSnake.java
+++ b/avaje-config/src/main/java/io/avaje/config/YamlLoaderSnake.java
@@ -3,6 +3,7 @@ package io.avaje.config;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.InputStream;
+import java.io.Reader;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -20,11 +21,20 @@ final class YamlLoaderSnake implements YamlLoader {
     this.yaml = new Yaml();
   }
 
-  @SuppressWarnings("unchecked")
+  @Override
+  public Map<String, String> load(Reader reader) {
+    return load(yaml.loadAll(reader));
+  }
+
   @Override
   public Map<String, String> load(InputStream is) {
+    return load(yaml.loadAll(is));
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, String> load(Iterable<Object> source) {
     Load load = new Load();
-    for (Object map : yaml.loadAll(is)) {
+    for (Object map : source) {
       load.loadMap((Map<String, Object>) map, null);
     }
     return load.map();

--- a/avaje-config/src/test/java/io/avaje/config/CoreConfigurationTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/CoreConfigurationTest.java
@@ -3,6 +3,7 @@ package io.avaje.config;
 import io.avaje.config.CoreEntry.CoreMap;
 import org.junit.jupiter.api.Test;
 
+import java.io.StringReader;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -41,6 +42,20 @@ class CoreConfigurationTest {
 
   private CoreConfiguration createConfig(CoreEntry.CoreMap entries) {
     return new CoreConfiguration(entries);
+  }
+
+  @Test
+  void parser() {
+    Configuration base = createSample();
+
+    ConfigParser yamlParser = base.parser("yaml").orElseThrow();
+
+    var ris = new StringReader("my.key: \n  other: 42\n  more.again: 52");
+    Map<String, String> keyValues = yamlParser.load(ris);
+    base.putAll(keyValues);
+
+    assertThat(base.get("my.key.other")).isEqualTo("42");
+    assertThat(base.getLong("my.key.more.again")).isEqualTo(52);
   }
 
   @Test

--- a/avaje-config/src/test/java/io/avaje/config/InitialLoaderTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/InitialLoaderTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class InitialLoaderTest {
 
   private static InitialLoader newInitialLoader() {
-    return new InitialLoader(new DefaultConfigurationLog(), new DefaultResourceLoader());
+    return new InitialLoader(new Parsers(), new DefaultConfigurationLog(), new DefaultResourceLoader());
   }
 
   @Test


### PR DESCRIPTION
Add configuration.parser(extension) to get access to underlying parsers that are registered

Change ConfigParser to support parsing Reader content