### PR TITLE
When logging ConfigurationSource only use the simpleName

### DIFF
--- a/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
@@ -123,7 +123,7 @@ final class CoreConfiguration implements Configuration {
   private void loadSources(Set<String> names) {
     for (ConfigurationSource source : sources) {
       source.load(this);
-      names.add("ConfigurationSource:" + source.getClass().getCanonicalName());
+      names.add("ConfigurationSource:" + source.getClass().getSimpleName());
     }
   }
 


### PR DESCRIPTION
I think that is sufficient to identify the source and the full name seems a tad ugly for my liking