### PR TITLE
Improves `load.properties` detection

### DIFF
--- a/avaje-config/src/main/java/io/avaje/config/InitialLoadContext.java
+++ b/avaje-config/src/main/java/io/avaje/config/InitialLoadContext.java
@@ -133,16 +133,19 @@ final class InitialLoadContext {
     return map;
   }
 
-  /** Read the special properties that can point to an external properties source. */
+  /**
+   * Read the special properties that can point to an external properties source.
+   */
   String indirectLocation() {
+    String location = System.getProperty("load.properties");
+    if (location != null) {
+      return location;
+    }
     var indirectLocation = map.get("load.properties");
-
     if (indirectLocation == null) {
       indirectLocation = map.get("load.properties.override");
     }
-    return indirectLocation == null
-        ? System.getProperty("load.properties")
-        : indirectLocation.value();
+    return indirectLocation == null ? null : indirectLocation.value();
   }
 
   String profiles() {

--- a/avaje-config/src/main/java/io/avaje/config/InitialLoadContext.java
+++ b/avaje-config/src/main/java/io/avaje/config/InitialLoadContext.java
@@ -133,15 +133,16 @@ final class InitialLoadContext {
     return map;
   }
 
-  /**
-   * Read the special properties that can point to an external properties source.
-   */
+  /** Read the special properties that can point to an external properties source. */
   String indirectLocation() {
     var indirectLocation = map.get("load.properties");
+
     if (indirectLocation == null) {
       indirectLocation = map.get("load.properties.override");
     }
-    return indirectLocation == null ? null : indirectLocation.value();
+    return indirectLocation == null
+        ? System.getProperty("load.properties")
+        : indirectLocation.value();
   }
 
   String profiles() {


### PR DESCRIPTION
it seems load properties was only detected if it was declared in a property file.

fixes #129 