### PR TITLE
Replace avaje-lang null annotations with JSpecify annotations

### DIFF
--- a/avaje-config/pom.xml
+++ b/avaje-config/pom.xml
@@ -27,9 +27,9 @@
   <dependencies>
 
     <dependency>
-      <groupId>io.avaje</groupId>
-      <artifactId>avaje-lang</artifactId>
-      <version>1.1</version>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+      <version>1.0.0</version>
     </dependency>
 
     <dependency>
@@ -83,17 +83,17 @@
         <artifactId>maven-repository-plugin</artifactId>
         <version>2.4</version>
       </plugin>
-<!--      <plugin>-->
-<!--        <groupId>org.sonatype.plugins</groupId>-->
-<!--        <artifactId>nexus-staging-maven-plugin</artifactId>-->
-<!--        <version>1.7.0</version>-->
-<!--        <extensions>true</extensions>-->
-<!--        <configuration>-->
-<!--          <serverId>ossrh</serverId>-->
-<!--          <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>-->
-<!--          <autoReleaseAfterClose>${nexus.staging.autoReleaseAfterClose}</autoReleaseAfterClose>-->
-<!--        </configuration>-->
-<!--      </plugin>-->
+      <!--      <plugin>-->
+      <!--        <groupId>org.sonatype.plugins</groupId>-->
+      <!--        <artifactId>nexus-staging-maven-plugin</artifactId>-->
+      <!--        <version>1.7.0</version>-->
+      <!--        <extensions>true</extensions>-->
+      <!--        <configuration>-->
+      <!--          <serverId>ossrh</serverId>-->
+      <!--          <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>-->
+      <!--          <autoReleaseAfterClose>${nexus.staging.autoReleaseAfterClose}</autoReleaseAfterClose>-->
+      <!--        </configuration>-->
+      <!--      </plugin>-->
     </plugins>
   </build>
 

--- a/avaje-config/src/main/java/io/avaje/config/Config.java
+++ b/avaje-config/src/main/java/io/avaje/config/Config.java
@@ -1,8 +1,5 @@
 package io.avaje.config;
 
-import io.avaje.lang.NonNullApi;
-import io.avaje.lang.Nullable;
-
 import java.math.BigDecimal;
 import java.net.URI;
 import java.time.Duration;
@@ -13,6 +10,9 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntConsumer;
 import java.util.function.LongConsumer;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Provides application Configuration based on loading properties and yaml files
@@ -78,7 +78,7 @@ import java.util.function.LongConsumer;
  *
  * }</pre>
  */
-@NonNullApi
+@NullMarked
 public class Config {
 
   private static final Configuration data = CoreConfiguration.initialise();

--- a/avaje-config/src/main/java/io/avaje/config/ConfigParser.java
+++ b/avaje-config/src/main/java/io/avaje/config/ConfigParser.java
@@ -1,15 +1,15 @@
 package io.avaje.config;
 
-import io.avaje.lang.NonNullApi;
-
 import java.io.InputStream;
 import java.io.Reader;
 import java.util.Map;
 
+import org.jspecify.annotations.NullMarked;
+
 /**
  * Load a config file into a flattened map.
  */
-@NonNullApi
+@NullMarked
 public interface ConfigParser extends ConfigExtension {
 
   /**

--- a/avaje-config/src/main/java/io/avaje/config/Configuration.java
+++ b/avaje-config/src/main/java/io/avaje/config/Configuration.java
@@ -1,8 +1,5 @@
 package io.avaje.config;
 
-import io.avaje.lang.NonNullApi;
-import io.avaje.lang.Nullable;
-
 import java.io.File;
 import java.math.BigDecimal;
 import java.net.URI;
@@ -12,6 +9,9 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntConsumer;
 import java.util.function.LongConsumer;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Configuration API for accessing property values and registering onChange listeners.
@@ -44,7 +44,7 @@ import java.util.function.LongConsumer;
  *
  * }</pre>
  */
-@NonNullApi
+@NullMarked
 public interface Configuration {
 
   /**

--- a/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
@@ -446,7 +446,7 @@ final class CoreConfiguration implements Configuration {
   @Override
   public void setProperty(String key, String newValue) {
     requireNonNull(key, "key is required");
-    requireNonNull(newValue, "newValue is required, use clearProperty()");
+    requireNonNull(newValue, "newValue is required, use clearProperty() to remove a property");
     eventBuilder("SetProperty").put(key, newValue).publish();
   }
 

--- a/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreConfiguration.java
@@ -1,7 +1,9 @@
 package io.avaje.config;
 
-import io.avaje.lang.NonNullApi;
-import io.avaje.lang.Nullable;
+import static io.avaje.config.Constants.SYSTEM_PROPS;
+import static io.avaje.config.Constants.USER_PROVIDED_DEFAULT;
+import static java.lang.System.Logger.Level.ERROR;
+import static java.util.Objects.requireNonNull;
 
 import java.lang.System.Logger.Level;
 import java.math.BigDecimal;
@@ -16,15 +18,13 @@ import java.util.function.Function;
 import java.util.function.IntConsumer;
 import java.util.function.LongConsumer;
 
-import static io.avaje.config.Constants.SYSTEM_PROPS;
-import static io.avaje.config.Constants.USER_PROVIDED_DEFAULT;
-import static java.lang.System.Logger.Level.ERROR;
-import static java.util.Objects.requireNonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Core implementation of Configuration.
  */
-@NonNullApi
+@NullMarked
 final class CoreConfiguration implements Configuration {
 
   private final Parsers parsers;

--- a/avaje-config/src/main/java/io/avaje/config/CoreConfigurationBuilder.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreConfigurationBuilder.java
@@ -1,6 +1,8 @@
 package io.avaje.config;
 
-import io.avaje.lang.NonNullApi;
+import static java.lang.System.Logger.Level.DEBUG;
+import static java.lang.System.Logger.Level.INFO;
+import static java.util.Objects.requireNonNull;
 
 import java.io.File;
 import java.io.FileReader;
@@ -9,11 +11,9 @@ import java.io.UncheckedIOException;
 import java.util.Map;
 import java.util.Properties;
 
-import static java.lang.System.Logger.Level.DEBUG;
-import static java.lang.System.Logger.Level.INFO;
-import static java.util.Objects.requireNonNull;
+import org.jspecify.annotations.NullMarked;
 
-@NonNullApi
+@NullMarked
 final class CoreConfigurationBuilder implements Configuration.Builder {
 
   private final CoreEntry.CoreMap sourceMap = CoreEntry.newMap();

--- a/avaje-config/src/main/java/io/avaje/config/CoreEntry.java
+++ b/avaje-config/src/main/java/io/avaje/config/CoreEntry.java
@@ -1,18 +1,18 @@
 package io.avaje.config;
 
-import io.avaje.lang.NonNullApi;
-import io.avaje.lang.Nullable;
+import static java.util.Objects.requireNonNull;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 
-import static java.util.Objects.requireNonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Configuration entry.
  */
-@NonNullApi
+@NullMarked
 final class CoreEntry implements Configuration.Entry {
 
   /**

--- a/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
+++ b/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
@@ -1,7 +1,8 @@
 package io.avaje.config;
 
-import io.avaje.config.CoreEntry.CoreMap;
-import io.avaje.lang.Nullable;
+import static io.avaje.config.InitialLoader.Source.FILE;
+import static io.avaje.config.InitialLoader.Source.RESOURCE;
+import static java.lang.System.Logger.Level.WARNING;
 
 import java.io.File;
 import java.io.IOException;
@@ -10,15 +11,17 @@ import java.io.UncheckedIOException;
 import java.util.*;
 import java.util.regex.Pattern;
 
-import static io.avaje.config.InitialLoader.Source.FILE;
-import static io.avaje.config.InitialLoader.Source.RESOURCE;
-import static java.lang.System.Logger.Level.WARNING;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import io.avaje.config.CoreEntry.CoreMap;
 
 /**
  * Loads the configuration from known/expected locations.
  * <p>
  * Defines the loading order of resources and files.
  */
+@NullMarked
 final class InitialLoader {
 
   private static final Pattern SPLIT_PATHS = Pattern.compile("[\\s,;]+");

--- a/avaje-config/src/main/java/io/avaje/config/PropertiesParser.java
+++ b/avaje-config/src/main/java/io/avaje/config/PropertiesParser.java
@@ -1,7 +1,5 @@
 package io.avaje.config;
 
-import io.avaje.lang.NonNullApi;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
@@ -11,10 +9,12 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
-@NonNullApi
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
 final class PropertiesParser implements ConfigParser {
 
-  private static final String[] extensions = new String[]{"properties"};
+  private static final String[] extensions = {"properties"};
 
   @Override
   public String[] supportedExtensions() {

--- a/avaje-config/src/main/java/io/avaje/config/ResourceLoader.java
+++ b/avaje-config/src/main/java/io/avaje/config/ResourceLoader.java
@@ -1,8 +1,8 @@
 package io.avaje.config;
 
-import io.avaje.lang.Nullable;
-
 import java.io.InputStream;
+
+import org.jspecify.annotations.Nullable;
 
 /**
  * Plugin API for loading resources typically from the classpath or module path.

--- a/avaje-config/src/main/java/io/avaje/config/YamlLoader.java
+++ b/avaje-config/src/main/java/io/avaje/config/YamlLoader.java
@@ -1,14 +1,14 @@
 package io.avaje.config;
 
-import io.avaje.lang.NonNullApi;
-
 import java.io.InputStream;
 import java.util.Map;
+
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Load Yaml config into a flattened map.
  */
-@NonNullApi
+@NullMarked
 interface YamlLoader extends ConfigParser {
 
   @Override

--- a/avaje-config/src/main/java/io/avaje/config/YamlLoaderSimple.java
+++ b/avaje-config/src/main/java/io/avaje/config/YamlLoaderSimple.java
@@ -1,14 +1,24 @@
 package io.avaje.config;
 
-import io.avaje.lang.NonNullApi;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.LineNumberReader;
+import java.io.Reader;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+import java.util.StringJoiner;
 
-import java.io.*;
-import java.util.*;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Simple YAML parser for loading yaml based config.
  */
-@NonNullApi
+@NullMarked
 final class YamlLoaderSimple implements YamlLoader {
 
   @Override

--- a/avaje-config/src/main/java/io/avaje/config/YamlLoaderSnake.java
+++ b/avaje-config/src/main/java/io/avaje/config/YamlLoaderSnake.java
@@ -1,19 +1,19 @@
 package io.avaje.config;
 
-import io.avaje.lang.NonNullApi;
-import org.yaml.snakeyaml.Yaml;
-
 import java.io.InputStream;
 import java.io.Reader;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
+import org.jspecify.annotations.NullMarked;
+import org.yaml.snakeyaml.Yaml;
 
 /**
  * Loads configuration from Yml into the load context.
  * <p>
  * Note that this ignores 'lists' so just reads 'maps' and scalar values.
  */
-@NonNullApi
+@NullMarked
 final class YamlLoaderSnake implements YamlLoader {
 
   private final Yaml yaml;

--- a/avaje-config/src/main/java/module-info.java
+++ b/avaje-config/src/main/java/module-info.java
@@ -2,11 +2,11 @@ module io.avaje.config {
 
   exports io.avaje.config;
 
-  requires transitive org.jspecify;
   requires transitive io.avaje.applog;
-  requires static org.yaml.snakeyaml;
 
   requires static io.avaje.spi;
+  requires static org.yaml.snakeyaml;
+  requires static transitive org.jspecify;
 
   uses io.avaje.config.ConfigExtension;
 

--- a/avaje-config/src/main/java/module-info.java
+++ b/avaje-config/src/main/java/module-info.java
@@ -2,7 +2,7 @@ module io.avaje.config {
 
   exports io.avaje.config;
 
-  requires transitive io.avaje.lang;
+  requires transitive org.jspecify;
   requires transitive io.avaje.applog;
   requires static org.yaml.snakeyaml;
 

--- a/avaje-dynamic-logback/src/main/java/module-info.java
+++ b/avaje-dynamic-logback/src/main/java/module-info.java
@@ -4,8 +4,6 @@ import io.avaje.config.dynamiclogback.LogbackPlugin;
 module io.avaje.config.dynamic.logback {
 
   requires io.avaje.config;
-  requires transitive io.avaje.lang;
-  requires transitive io.avaje.applog;
 
   requires static io.avaje.spi;
   requires static org.slf4j;


### PR DESCRIPTION
avaje-lang has jsr-305 based null annotations. 
- Replaces avaje-lang `@NonNullApi` with JSpecify `@NullMarked`
- Replaces avaje-lang `@Nullable` with JSpecify `@Nullable`

Refer to https://jspecify.dev/docs/using#if-your-code-already-uses-jsr-305-annotations for differences we might see with this change

Also refer to https://jspecify.dev/docs/tool-conformance ... for more details on tooling support 