### PR TITLE
Add avaje-config-json

### DIFF
--- a/avaje-config-json/pom.xml
+++ b/avaje-config-json/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.avaje</groupId>
+    <artifactId>java11-oss</artifactId>
+    <version>4.4</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>io.avaje</groupId>
+  <artifactId>avaje-config-json</artifactId>
+  <version>4.1-SNAPSHOT</version>
+
+  <scm>
+    <connection>scm:git:git@github.com:avaje/avaje-config.git</connection>
+    <developerConnection>scm:git:git@github.com:avaje/avaje-config.git</developerConnection>
+    <tag>HEAD</tag>
+  </scm>
+
+  <properties>
+    <snakeyaml.version>2.3</snakeyaml.version>
+    <nexus.staging.autoReleaseAfterClose>true</nexus.staging.autoReleaseAfterClose>
+    <surefire.useModulePath>false</surefire.useModulePath>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-config</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-jsonb</artifactId>
+      <version>2.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>junit</artifactId>
+      <version>1.5</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.5.7</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-applog-slf4j</artifactId>
+      <version>1.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-repository-plugin</artifactId>
+        <version>2.4</version>
+      </plugin>
+      <!--      <plugin>-->
+      <!--        <groupId>org.sonatype.plugins</groupId>-->
+      <!--        <artifactId>nexus-staging-maven-plugin</artifactId>-->
+      <!--        <version>1.7.0</version>-->
+      <!--        <extensions>true</extensions>-->
+      <!--        <configuration>-->
+      <!--          <serverId>ossrh</serverId>-->
+      <!--          <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>-->
+      <!--          <autoReleaseAfterClose>${nexus.staging.autoReleaseAfterClose}</autoReleaseAfterClose>-->
+      <!--        </configuration>-->
+      <!--      </plugin>-->
+    </plugins>
+  </build>
+
+</project>

--- a/avaje-config-json/src/main/java/io/avaje/config/json/JsonParser.java
+++ b/avaje-config-json/src/main/java/io/avaje/config/json/JsonParser.java
@@ -1,0 +1,41 @@
+package io.avaje.config.json;
+
+import io.avaje.config.ConfigParser;
+import io.avaje.jsonb.Jsonb;
+import io.avaje.jsonb.Types;
+import org.jspecify.annotations.NullMarked;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.util.Map;
+
+@NullMarked
+final class JsonParser implements ConfigParser {
+
+  private static final String[] extensions = {"json"};
+
+  private final Jsonb jsonb;
+
+  JsonParser() {
+    this.jsonb = Jsonb.builder()
+      .failOnUnknown(false)
+      .serializeEmpty(true)
+      .serializeNulls(true)
+      .build();
+  }
+
+  @Override
+  public String[] supportedExtensions() {
+    return extensions;
+  }
+
+  @Override
+  public Map<String, String> load(Reader reader) {
+    return (Map<String, String>) this.jsonb.type(Types.mapOf(String.class)).fromJson(reader);
+  }
+
+  @Override
+  public Map<String, String> load(InputStream is) {
+    return (Map<String, String>) this.jsonb.type(Types.mapOf(String.class)).fromJson(is);
+  }
+}

--- a/avaje-config-json/src/main/java/module-info.java
+++ b/avaje-config-json/src/main/java/module-info.java
@@ -1,0 +1,10 @@
+module io.avaje.config.json {
+
+  requires io.avaje.config;
+  requires io.avaje.jsonb;
+
+  exports io.avaje.config.json;
+
+  uses io.avaje.config.ConfigExtension;
+
+}

--- a/avaje-config-json/src/test/java/io/avaje/config/json/JsonParserTest.java
+++ b/avaje-config-json/src/test/java/io/avaje/config/json/JsonParserTest.java
@@ -1,0 +1,51 @@
+package io.avaje.config.json;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class JsonParserTest {
+
+  @Test
+  void supportedExtensions() {
+    var parser = new JsonParser();
+    assertThat(parser.supportedExtensions()).isEqualTo(new String[]{"json"});
+  }
+
+  private static String input() {
+    return "{" +
+      "\"one.key\": \"a\"," +
+      "\"one.key2\": \"b\"," +
+      "\"key3\": \"c\"" +
+    "}";
+  }
+
+  @Test
+  void load_reader() {
+    var parser = new JsonParser();
+    Map<String, String> map = parser.load(new StringReader(input()));
+
+    assertThat(map).hasSize(3);
+    assertThat(map).containsOnlyKeys("one.key", "one.key2", "key3");
+    assertThat(map).containsEntry("one.key", "a");
+    assertThat(map).containsEntry("one.key2", "b");
+    assertThat(map).containsEntry("key3", "c");
+  }
+
+  @Test
+  void load_inputStream() {
+    var parser = new JsonParser();
+    Map<String, String> map = parser.load(new ByteArrayInputStream(input().getBytes(StandardCharsets.UTF_8)));
+
+    assertThat(map).hasSize(3);
+    assertThat(map).containsOnlyKeys("one.key", "one.key2", "key3");
+    assertThat(map).containsEntry("one.key", "a");
+    assertThat(map).containsEntry("one.key2", "b");
+    assertThat(map).containsEntry("key3", "c");
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
 
   <modules>
     <module>avaje-config</module>
+    <module>avaje-config-json</module>
     <module>avaje-aws-appconfig</module>
     <module>avaje-dynamic-logback</module>
   </modules>


### PR DESCRIPTION
An experiment, created a simple parser with `jsonb` dependency as a separate module.

Did this because I saw #94 was closed, and this seemed like the first simple thing that never got done, adding rudimentary JSON support like another one of the languages here seems quite simple?

If we want to do more advanced stuff, like destructure a more nested JSON structure into key/value with `.` to seperate the levels. for example:
```
{
    "postgresql": {
        "host": "127.0.0.1"
    }
}
```
to be destructured into
"postgresql.host" = "127.0.0.1"
in the `Map<String, String>`,

this pull request does not achieve that. It will only support a flat JSON structure.
I didn't check what the YAML parser does.

Go ahead and make changes to this PR if you think it's a good idea, close it if not