### PR TITLE
Add avaje-config-toml

### DIFF
--- a/avaje-config-toml/pom.xml
+++ b/avaje-config-toml/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.avaje</groupId>
+    <artifactId>java11-oss</artifactId>
+    <version>4.4</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>io.avaje</groupId>
+  <artifactId>avaje-config-toml</artifactId>
+  <version>4.1-SNAPSHOT</version>
+
+  <scm>
+    <connection>scm:git:git@github.com:avaje/avaje-config.git</connection>
+    <developerConnection>scm:git:git@github.com:avaje/avaje-config.git</developerConnection>
+    <tag>HEAD</tag>
+  </scm>
+
+  <properties>
+    <snakeyaml.version>2.3</snakeyaml.version>
+    <nexus.staging.autoReleaseAfterClose>true</nexus.staging.autoReleaseAfterClose>
+    <surefire.useModulePath>false</surefire.useModulePath>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-config</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.tomlj</groupId>
+      <artifactId>tomlj</artifactId>
+      <version>1.1.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>junit</artifactId>
+      <version>1.5</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.5.7</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-applog-slf4j</artifactId>
+      <version>1.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-repository-plugin</artifactId>
+        <version>2.4</version>
+      </plugin>
+      <!--      <plugin>-->
+      <!--        <groupId>org.sonatype.plugins</groupId>-->
+      <!--        <artifactId>nexus-staging-maven-plugin</artifactId>-->
+      <!--        <version>1.7.0</version>-->
+      <!--        <extensions>true</extensions>-->
+      <!--        <configuration>-->
+      <!--          <serverId>ossrh</serverId>-->
+      <!--          <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>-->
+      <!--          <autoReleaseAfterClose>${nexus.staging.autoReleaseAfterClose}</autoReleaseAfterClose>-->
+      <!--        </configuration>-->
+      <!--      </plugin>-->
+    </plugins>
+  </build>
+
+</project>

--- a/avaje-config-toml/pom.xml
+++ b/avaje-config-toml/pom.xml
@@ -19,8 +19,6 @@
   </scm>
 
   <properties>
-    <snakeyaml.version>2.3</snakeyaml.version>
-    <nexus.staging.autoReleaseAfterClose>true</nexus.staging.autoReleaseAfterClose>
     <surefire.useModulePath>false</surefire.useModulePath>
   </properties>
 
@@ -57,26 +55,5 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-repository-plugin</artifactId>
-        <version>2.4</version>
-      </plugin>
-      <!--      <plugin>-->
-      <!--        <groupId>org.sonatype.plugins</groupId>-->
-      <!--        <artifactId>nexus-staging-maven-plugin</artifactId>-->
-      <!--        <version>1.7.0</version>-->
-      <!--        <extensions>true</extensions>-->
-      <!--        <configuration>-->
-      <!--          <serverId>ossrh</serverId>-->
-      <!--          <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>-->
-      <!--          <autoReleaseAfterClose>${nexus.staging.autoReleaseAfterClose}</autoReleaseAfterClose>-->
-      <!--        </configuration>-->
-      <!--      </plugin>-->
-    </plugins>
-  </build>
 
 </project>

--- a/avaje-config-toml/src/main/java/io/avaje/config/toml/TomlParser.java
+++ b/avaje-config-toml/src/main/java/io/avaje/config/toml/TomlParser.java
@@ -1,0 +1,45 @@
+package io.avaje.config.toml;
+
+import io.avaje.config.ConfigParser;
+import org.jspecify.annotations.NullMarked;
+import org.tomlj.Toml;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.UncheckedIOException;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@NullMarked
+final class TomlParser implements ConfigParser {
+
+  private static final String[] extensions = {"toml"};
+
+  @Override
+  public String[] supportedExtensions() {
+    return extensions;
+  }
+
+  @Override
+  public Map<String, String> load(Reader reader) {
+    try {
+      return Toml.parse(reader).dottedEntrySet()
+        .stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, entry -> String.valueOf(entry.getValue())));
+    } catch (IOException exception) {
+      throw new UncheckedIOException(exception);
+    }
+  }
+
+  @Override
+  public Map<String, String> load(InputStream is) {
+    try {
+      return Toml.parse(is).dottedEntrySet()
+        .stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, entry -> String.valueOf(entry.getValue())));
+    } catch (IOException exception) {
+      throw new UncheckedIOException(exception);
+    }
+  }
+}

--- a/avaje-config-toml/src/main/java/io/avaje/config/toml/TomlParser.java
+++ b/avaje-config-toml/src/main/java/io/avaje/config/toml/TomlParser.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 @NullMarked
-final class TomlParser implements ConfigParser {
+public final class TomlParser implements ConfigParser {
 
   private static final String[] extensions = {"toml"};
 

--- a/avaje-config-toml/src/main/java/module-info.java
+++ b/avaje-config-toml/src/main/java/module-info.java
@@ -1,0 +1,10 @@
+module io.avaje.config.toml {
+
+  requires io.avaje.config;
+  requires org.tomlj;
+
+  exports io.avaje.config.toml;
+
+  uses io.avaje.config.ConfigExtension;
+
+}

--- a/avaje-config-toml/src/main/java/module-info.java
+++ b/avaje-config-toml/src/main/java/module-info.java
@@ -1,3 +1,5 @@
+import io.avaje.config.toml.TomlParser;
+
 module io.avaje.config.toml {
 
   requires io.avaje.config;
@@ -5,6 +7,6 @@ module io.avaje.config.toml {
 
   exports io.avaje.config.toml;
 
-  uses io.avaje.config.ConfigExtension;
+  provides io.avaje.config.ConfigExtension with TomlParser;
 
 }

--- a/avaje-config-toml/src/main/resources/META-INF/services/io.avaje.config.ConfigExtension
+++ b/avaje-config-toml/src/main/resources/META-INF/services/io.avaje.config.ConfigExtension
@@ -1,0 +1,1 @@
+io.avaje.config.toml.TomlParser

--- a/avaje-config-toml/src/test/java/io/avaje/config/toml/TomlParserTest.java
+++ b/avaje-config-toml/src/test/java/io/avaje/config/toml/TomlParserTest.java
@@ -9,7 +9,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.*;
 
-public class TomlParserTest {
+class TomlParserTest {
 
   @Test
   void supportedExtensions() {

--- a/avaje-config-toml/src/test/java/io/avaje/config/toml/TomlParserTest.java
+++ b/avaje-config-toml/src/test/java/io/avaje/config/toml/TomlParserTest.java
@@ -1,0 +1,51 @@
+package io.avaje.config.toml;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class TomlParserTest {
+
+  @Test
+  void supportedExtensions() {
+    var parser = new TomlParser();
+    assertThat(parser.supportedExtensions()).isEqualTo(new String[]{"toml"});
+  }
+
+  private static String input() {
+    return "key3 = \"c\"\n" +
+      "\n" +
+      "[one]\n" +
+      "key = \"a\"\n" +
+      "key2 = \"b\"\n";
+  }
+
+  @Test
+  void load_reader() {
+    var parser = new TomlParser();
+    Map<String, String> map = parser.load(new StringReader(input()));
+
+    assertThat(map).hasSize(3);
+    assertThat(map).containsOnlyKeys("one.key", "one.key2", "key3");
+    assertThat(map).containsEntry("one.key", "a");
+    assertThat(map).containsEntry("one.key2", "b");
+    assertThat(map).containsEntry("key3", "c");
+  }
+
+  @Test
+  void load_inputStream() {
+    var parser = new TomlParser();
+    Map<String, String> map = parser.load(new ByteArrayInputStream(input().getBytes(StandardCharsets.UTF_8)));
+
+    assertThat(map).hasSize(3);
+    assertThat(map).containsOnlyKeys("one.key", "one.key2", "key3");
+    assertThat(map).containsEntry("one.key", "a");
+    assertThat(map).containsEntry("one.key2", "b");
+    assertThat(map).containsEntry("key3", "c");
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
 
   <modules>
     <module>avaje-config</module>
+    <module>avaje-config-toml</module>
     <module>avaje-aws-appconfig</module>
     <module>avaje-dynamic-logback</module>
   </modules>


### PR DESCRIPTION
Added TOML support. This supports dotted nesting.

It uses a tiny library, `tomlj`, not to be confused with `toml4j`
This library has one dependency, on ANTLR, for parsing, which itself has zero dependencies.

`avaje-config-toml`->`tomlj`->`antlr4-runtime`

# Example

(from the test):
Given:
```toml
key3 = "c"

[one]
key = "a"
key2 = "b"
```
When:
```java
var parser = new TomlParser();
Map<String, String> map = parser.load(new StringReader(input()));

assertThat(map).hasSize(3);
assertThat(map).containsOnlyKeys("one.key", "one.key2", "key3");
assertThat(map).containsEntry("one.key", "a");
assertThat(map).containsEntry("one.key2", "b");
assertThat(map).containsEntry("key3", "c");
```

Then:
test passes