### PR TITLE
Implement support for most TOML types

### DIFF
--- a/avaje-config-toml/src/main/java/io/avaje/config/toml/TomlParser.java
+++ b/avaje-config-toml/src/main/java/io/avaje/config/toml/TomlParser.java
@@ -3,6 +3,7 @@ package io.avaje.config.toml;
 import io.avaje.config.ConfigParser;
 import org.jspecify.annotations.NullMarked;
 import org.tomlj.Toml;
+import org.tomlj.TomlArray;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,7 +27,7 @@ public final class TomlParser implements ConfigParser {
     try {
       return Toml.parse(reader).dottedEntrySet()
         .stream()
-        .collect(Collectors.toMap(Map.Entry::getKey, entry -> String.valueOf(entry.getValue())));
+        .collect(Collectors.toMap(Map.Entry::getKey, entry -> readTomlValue(entry.getValue())));
     } catch (IOException exception) {
       throw new UncheckedIOException(exception);
     }
@@ -37,9 +38,19 @@ public final class TomlParser implements ConfigParser {
     try {
       return Toml.parse(is).dottedEntrySet()
         .stream()
-        .collect(Collectors.toMap(Map.Entry::getKey, entry -> String.valueOf(entry.getValue())));
+        .collect(Collectors.toMap(Map.Entry::getKey, entry -> readTomlValue(entry.getValue())));
     } catch (IOException exception) {
       throw new UncheckedIOException(exception);
     }
+  }
+
+  private static String readTomlValue(Object object) {
+    if (object instanceof TomlArray) {
+      TomlArray array = (TomlArray) object;
+      return array.toList().stream()
+        .map(TomlParser::readTomlValue)
+        .collect(Collectors.joining(";"));
+    }
+    return String.valueOf(object);
   }
 }

--- a/avaje-config-toml/src/test/java/io/avaje/config/toml/TomlParserTest.java
+++ b/avaje-config-toml/src/test/java/io/avaje/config/toml/TomlParserTest.java
@@ -18,11 +18,17 @@ class TomlParserTest {
   }
 
   private static String input() {
-    return "key3 = \"c\"\n" +
+    return "key = \"c\"\n" +
       "\n" +
       "[one]\n" +
-      "key = \"a\"\n" +
-      "key2 = \"b\"\n";
+      "key1 = \"a\"\n" +
+      "key2 = \"b\"\n" +
+      "key3 = [\"a\", \"b\", \"c\"]\n" +
+      "[two]\n" +
+      "local_datetime = 2024-09-09T15:30:00\n" +
+      "local_date = 2024-09-09\n" +
+      "local_time = 15:30:00\n" +
+      "offset_datetime = 2024-09-09T15:30:00+02:00";
   }
 
   @Test
@@ -30,11 +36,21 @@ class TomlParserTest {
     var parser = new TomlParser();
     Map<String, String> map = parser.load(new StringReader(input()));
 
-    assertThat(map).hasSize(3);
-    assertThat(map).containsOnlyKeys("one.key", "one.key2", "key3");
-    assertThat(map).containsEntry("one.key", "a");
+    assertThat(map).hasSize(8);
+    assertThat(map).containsOnlyKeys("key",
+      "one.key1", "one.key2", "one.key3",
+      "two.local_datetime", "two.local_date", "two.local_time", "two.offset_datetime");
+
+    assertThat(map).containsEntry("key", "c");
+
+    assertThat(map).containsEntry("one.key1", "a");
     assertThat(map).containsEntry("one.key2", "b");
-    assertThat(map).containsEntry("key3", "c");
+    assertThat(map).containsEntry("one.key3", "a;b;c");
+
+    assertThat(map).containsEntry("two.local_datetime", "2024-09-09T15:30");
+    assertThat(map).containsEntry("two.local_date", "2024-09-09");
+    assertThat(map).containsEntry("two.local_time", "15:30");
+    assertThat(map).containsEntry("two.offset_datetime", "2024-09-09T15:30+02:00");
   }
 
   @Test
@@ -42,10 +58,20 @@ class TomlParserTest {
     var parser = new TomlParser();
     Map<String, String> map = parser.load(new ByteArrayInputStream(input().getBytes(StandardCharsets.UTF_8)));
 
-    assertThat(map).hasSize(3);
-    assertThat(map).containsOnlyKeys("one.key", "one.key2", "key3");
-    assertThat(map).containsEntry("one.key", "a");
+    assertThat(map).hasSize(8);
+    assertThat(map).containsOnlyKeys("key",
+      "one.key1", "one.key2", "one.key3",
+      "two.local_datetime", "two.local_date", "two.local_time", "two.offset_datetime");
+
+    assertThat(map).containsEntry("key", "c");
+
+    assertThat(map).containsEntry("one.key1", "a");
     assertThat(map).containsEntry("one.key2", "b");
-    assertThat(map).containsEntry("key3", "c");
+    assertThat(map).containsEntry("one.key3", "a;b;c");
+
+    assertThat(map).containsEntry("two.local_datetime", "2024-09-09T15:30");
+    assertThat(map).containsEntry("two.local_date", "2024-09-09");
+    assertThat(map).containsEntry("two.local_time", "15:30");
+    assertThat(map).containsEntry("two.offset_datetime", "2024-09-09T15:30+02:00");
   }
 }


### PR DESCRIPTION
With the original implementation in my PR, arrays were not supported, and the other types in TOML were not specifically tested.
Feel free to make changes to the unit test, if you find this too bloated.

# TOML types: string, integer, float, boolean, offset date-time, local date-time, local date, local time, array, table

## string, integer, float, boolean
All working before

## array
I have implemented arrays by deserializing their contents well, and joining with `;`.
This is how environment variables work, and properties seems to have common conventions.

I am unsure how Avaje Config supports lists, currently. Is it by repeating the same key multiple times, with each value? If that's the case I could implement it this way instead.

## local date, local time, local date-time, offset date-time
Maps to JVM - LocalDate, LocalTime, LocalDateTime, and OffsetDateTime.
They have direct implementation in TOML, and the toString() is called from the JVM class to give us a string in the map.
This leaves us with an ISO-8601 value.

This value can be immediately passed in to the static `parse` methods, e.g. `LocalTime#parse`, if someone wants to use these TOML features easily.
`var time = LocalTime.parse(Config.get("some_localtime"))`

## table
Intermediary tables are not supported, but the normal tables are "un-nested", i.e., dotted, and this was working before.

Intermediary table:
``some_key = { one: 1.0, two: 5.0 }``

I don't know yet if it would be worth implementing this, because with the API that `avaje-config` exposes, it would be hard to actually use them?

For basic ones like this, the parser can be further expanded to "un-nest" them, i.e. make new dotted keys for their contents

But what about intermediary tables, in arrays? Users can't read them with our API right now, so they shouldn't use them
If using them, the value will read `org.tomlj.MutableTomlTable@2u0rjqai`, etc.
 