### PR TITLE
Expand load.properties values with profiles

### DIFF
--- a/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
+++ b/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
@@ -24,7 +24,7 @@ import io.avaje.config.CoreEntry.CoreMap;
 @NullMarked
 final class InitialLoader {
 
-  private static final Pattern SPLIT_PATHS = Pattern.compile("[\\s,;]+");
+ private static final Pattern SPLIT_PATHS = Pattern.compile("[\\s,;]+");
 
   /**
    * Return the Expression evaluator using the given properties.
@@ -190,23 +190,18 @@ final class InitialLoader {
   /**
    * Load configuration defined by a <em>load.properties</em> entry in properties file.
    */
-  private void loadViaIndirection() {
+  void loadViaIndirection() {
     String paths = loadContext.indirectLocation();
     if (paths != null) {
       loadViaPaths(paths);
     }
   }
 
-  private String@Nullable[] profiles() {
-    final String paths = loadContext.profiles();
-    return paths == null ? null : splitPaths(paths);
-  }
-
   /**
    * Load configuration defined by a <em>config.profiles</em> property.
    */
   private void loadViaProfiles(Source source) {
-    final var profiles = profiles();
+    final var profiles = loadContext.profiles();
     if (profiles != null) {
       for (final String path : profiles) {
         final var profile = loadContext.eval(path);
@@ -227,7 +222,7 @@ final class InitialLoader {
     return loadContext.size();
   }
 
-  String[] splitPaths(String location) {
+  static String[] splitPaths(String location) {
     return SPLIT_PATHS.split(location);
   }
 

--- a/avaje-config/src/test/java/io/avaje/config/InitialLoaderTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/InitialLoaderTest.java
@@ -124,12 +124,13 @@ class InitialLoaderTest {
   void loadViaIndirection_Profiles() {
     InitialLoader loader = newInitialLoader();
     loader.entryMap().put("avaje.profiles", "a,b,c", "test");
-    loader.entryMap().put("load.properties", "application-test-${avaje.profiles}.properties", "test");
+    loader.entryMap().put("getsuga", "tensho.properties", "test");
+    loader.entryMap().put("load.properties", "${getsuga},application-test-${avaje.profiles}.properties", "test");
     loader.loadViaIndirection();
 
     assertEquals(
         loader.entryMap().get("load.properties").value(),
-        "application-test-a.properties,application-test-b.properties,application-test-c.properties");
+        "tensho.properties,application-test-a.properties,application-test-b.properties,application-test-c.properties");
   }
 
   @Test

--- a/avaje-config/src/test/java/io/avaje/config/InitialLoaderTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/InitialLoaderTest.java
@@ -121,6 +121,18 @@ class InitialLoaderTest {
   }
 
   @Test
+  void loadViaIndirection_Profiles() {
+    InitialLoader loader = newInitialLoader();
+    loader.entryMap().put("avaje.profiles", "a,b,c", "test");
+    loader.entryMap().put("load.properties", "application-test-${avaje.profiles}.properties", "test");
+    loader.loadViaIndirection();
+
+    assertEquals(
+        loader.entryMap().get("load.properties").value(),
+        "application-test-a.properties,application-test-b.properties,application-test-c.properties");
+  }
+
+  @Test
   void load_withSuppressTestResource() {
     //application-test.yaml is loaded when suppressTestResource is not set to true
     try {


### PR DESCRIPTION
Updates `InitialLoader` such that 

```
avaje.profiles=live,canary // can also use the AVAJE_PROFILES env variable
custom=custom.properties
load.properties=${custom}, application-special-${avaje.profiles}.properties
```
effectively becomes
```
avaje.profiles=live,canary
custom=custom.properties
load.properties=custom.properties,application-special-live.properties,application-special-canary.properties
```
