### PR TITLE
Add a flag to determine file/resource bitwise loading 

### DIFF
--- a/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
+++ b/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
@@ -42,7 +42,7 @@ final class InitialLoader {
   private final InitialLoadContext loadContext;
   private final Set<String> profileResourceLoaded = new HashSet<>();
   private final Parsers parsers;
-  private final boolean SINGLE_LOAD = Boolean.getBoolean("config.single.load");
+  private final boolean singleLoad = Boolean.getBoolean("config.single.load");
 
   InitialLoader(CoreComponents components, ResourceLoader resourceLoader) {
     this.parsers = components.parsers();
@@ -255,7 +255,8 @@ final class InitialLoader {
   boolean loadWithExtensionCheck(String fileName) {
     var extension = fileName.substring(fileName.lastIndexOf(".") + 1);
     if ("properties".equals(extension)) {
-      return loadProperties(fileName, RESOURCE) | (SINGLE_LOAD || loadProperties(fileName, FILE));
+      var loadedProperties = loadProperties(fileName, RESOURCE);
+      return loadedProperties | (singleLoad && loadedProperties || loadProperties(fileName, FILE));
     } else {
       var parser = parsers.get(extension);
       if (parser == null) {
@@ -267,8 +268,10 @@ final class InitialLoader {
             + "]");
       }
 
-      return loadCustomExtension(fileName, parser, RESOURCE)
-          | (SINGLE_LOAD || loadCustomExtension(fileName, parser, FILE));
+      var loadedProperties = loadCustomExtension(fileName, parser, RESOURCE);
+
+      return loadedProperties
+          | (singleLoad && loadedProperties || loadCustomExtension(fileName, parser, FILE));
     }
   }
 

--- a/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
+++ b/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
@@ -25,6 +25,7 @@ import io.avaje.config.CoreEntry.CoreMap;
 final class InitialLoader {
 
   private static final Pattern SPLIT_PATHS = Pattern.compile("[\\s,;]+");
+  private static final boolean SINGLE_LOAD = Boolean.getBoolean("config.single.load");
 
   /**
    * Return the Expression evaluator using the given properties.
@@ -254,7 +255,7 @@ final class InitialLoader {
   boolean loadWithExtensionCheck(String fileName) {
     var extension = fileName.substring(fileName.lastIndexOf(".") + 1);
     if ("properties".equals(extension)) {
-      return loadProperties(fileName, RESOURCE) || loadProperties(fileName, FILE);
+      return loadProperties(fileName, RESOURCE) | (SINGLE_LOAD || loadProperties(fileName, FILE));
     } else {
       var parser = parsers.get(extension);
       if (parser == null) {
@@ -267,7 +268,7 @@ final class InitialLoader {
       }
 
       return loadCustomExtension(fileName, parser, RESOURCE)
-        || loadCustomExtension(fileName, parser, FILE);
+          | (SINGLE_LOAD || loadCustomExtension(fileName, parser, FILE));
     }
   }
 

--- a/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
+++ b/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
@@ -254,7 +254,7 @@ final class InitialLoader {
   boolean loadWithExtensionCheck(String fileName) {
     var extension = fileName.substring(fileName.lastIndexOf(".") + 1);
     if ("properties".equals(extension)) {
-      return loadProperties(fileName, RESOURCE) | loadProperties(fileName, FILE);
+      return loadProperties(fileName, RESOURCE) || loadProperties(fileName, FILE);
     } else {
       var parser = parsers.get(extension);
       if (parser == null) {
@@ -267,7 +267,7 @@ final class InitialLoader {
       }
 
       return loadCustomExtension(fileName, parser, RESOURCE)
-        | loadCustomExtension(fileName, parser, FILE);
+        || loadCustomExtension(fileName, parser, FILE);
     }
   }
 

--- a/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
+++ b/avaje-config/src/main/java/io/avaje/config/InitialLoader.java
@@ -25,7 +25,6 @@ import io.avaje.config.CoreEntry.CoreMap;
 final class InitialLoader {
 
   private static final Pattern SPLIT_PATHS = Pattern.compile("[\\s,;]+");
-  private static final boolean SINGLE_LOAD = Boolean.getBoolean("config.single.load");
 
   /**
    * Return the Expression evaluator using the given properties.
@@ -43,6 +42,7 @@ final class InitialLoader {
   private final InitialLoadContext loadContext;
   private final Set<String> profileResourceLoaded = new HashSet<>();
   private final Parsers parsers;
+  private final boolean SINGLE_LOAD = Boolean.getBoolean("config.single.load");
 
   InitialLoader(CoreComponents components, ResourceLoader resourceLoader) {
     this.parsers = components.parsers();

--- a/avaje-config/src/test/java/io/avaje/config/InitialLoaderTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/InitialLoaderTest.java
@@ -48,7 +48,7 @@ class InitialLoaderTest {
     var properties = evalFor(loader.entryMap());
     assertThat(properties.get("dummy.yaml.bar").value()).isEqualTo("baz");
     assertThat(properties.get("dummy.yml.foo").value()).isEqualTo("bar");
-    assertThat(properties.get("dummy.properties.foo").value()).isEqualTo("bar");
+    assertThat(properties.get("dummy.properties.foo").value()).isEqualTo("bazz");
     assertThat(properties.get("dummy.properties.a").value()).isEqualTo("fromResource");
   }
 

--- a/avaje-config/src/test/java/io/avaje/config/InitialLoaderTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/InitialLoaderTest.java
@@ -53,6 +53,24 @@ class InitialLoaderTest {
   }
 
   @Test
+  void loadWithExtensionCheck_Single_Load() {
+    System.setProperty("config.single.load", "true");
+    InitialLoader loader = newInitialLoader();
+    loader.loadWithExtensionCheck("test-dummy.properties");
+    loader.loadWithExtensionCheck("test-dummy.yml");
+    loader.loadWithExtensionCheck("test-dummy2.yaml");
+
+    var properties = evalFor(loader.entryMap());
+    assertThat(properties.get("dummy.yaml.bar").value()).isEqualTo("baz");
+    assertThat(properties.get("dummy.yml.foo").value()).isEqualTo("bar");
+    assertThat(properties.get("dummy.properties.foo").value()).isEqualTo("bazz");
+    assertThat(properties.get("dummy.properties.a").value()).isEqualTo("fromResource");
+
+    System.setProperty("config.single.load", "false");
+  }
+
+
+  @Test
   void loadYaml() {
     InitialLoader loader = newInitialLoader();
     loader.loadWithExtensionCheck("test-properties/foo.yml");

--- a/avaje-config/src/test/java/io/avaje/config/InitialLoaderTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/InitialLoaderTest.java
@@ -48,7 +48,7 @@ class InitialLoaderTest {
     var properties = evalFor(loader.entryMap());
     assertThat(properties.get("dummy.yaml.bar").value()).isEqualTo("baz");
     assertThat(properties.get("dummy.yml.foo").value()).isEqualTo("bar");
-    assertThat(properties.get("dummy.properties.foo").value()).isEqualTo("bazz");
+    assertThat(properties.get("dummy.properties.foo").value()).isEqualTo("bar");
     assertThat(properties.get("dummy.properties.a").value()).isEqualTo("fromResource");
   }
 


### PR DESCRIPTION
Currently, we make two resource calls for one resource 99% of the time.

a resource call is nontrivial in cost. We can do interpolation all day long on giant lists of key values but make a file call or classpath load and it's a solid 30ms for each one until the disk cache gets happy.

- Detect the `config.single.load` property to not use bitwise to load files/resources