### PR TITLE
[avaje-aws-appconfig] Add retry loop for initial load

### DIFF
--- a/avaje-dynamic-logback/pom.xml
+++ b/avaje-dynamic-logback/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>io.avaje</groupId>
   <artifactId>avaje-dynamic-logback</artifactId>
-  <version>1.1</version>
+  <version>1.2</version>
 
   <url>https://github.com/avaje/avaje-config/tree/master/avaje-dynamic-logback</url>
 
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-config</artifactId>
-      <version>4.1-SNAPSHOT</version>
+      <version>4.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
In K8s with the AWS AppConfig sidecar, there is a race condition between the startup of the application and the AppConfig sidecar.

This adds a simple retry loop for the initial load from AWS AppConfig. Maximum of 10 attempts with 250 millis pause between events.