### PR TITLE
[yml] Handle YAML edge cases / List of objects

### DIFF
--- a/avaje-config/src/main/java/io/avaje/config/YamlLoaderSimple.java
+++ b/avaje-config/src/main/java/io/avaje/config/YamlLoaderSimple.java
@@ -15,7 +15,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.StringJoiner;
 
 import org.jspecify.annotations.NullMarked;
 
@@ -54,6 +53,7 @@ final class YamlLoaderSimple implements YamlLoader {
     private final Map<String, String> keyValues = new LinkedHashMap<>();
     private final Deque<Key> keyStack = new ArrayDeque<>();
     private final List<String> multiLines = new ArrayList<>();
+    private final Map<String, Integer> listCounters = new LinkedHashMap<>();
 
     private State state = State.RequireKey;
     private MultiLineTrim multiLineTrim = MultiLineTrim.Clip;
@@ -185,36 +185,68 @@ final class YamlLoaderSimple implements YamlLoader {
         return;
       }
 
+      if (currentIndent < line.length() && line.charAt(currentIndent) == '-') {
+        int afterDashStart = currentIndent + 1;
+        while (afterDashStart < line.length() && line.charAt(afterDashStart) == ' ') {
+          afterDashStart++;
+        }
+        final String afterDash = line.substring(afterDashStart);
+        final int colonPos = afterDash.indexOf(':');
+        final boolean isObjectItem = colonPos > 0
+            && (colonPos == afterDash.length() - 1 || afterDash.charAt(colonPos + 1) == ' ');
+        if (isObjectItem) {
+          processObjectListItem(afterDash);
+        } else {
+          processNonKey(line, true);
+        }
+        return;
+      }
+
       final int pos = line.indexOf(':');
-      var list = line.stripLeading().charAt(0) == '-';
-      if (pos == -1 || list) {
-        // value on another line
-        processNonKey(line, list);
+      if (pos == -1) {
+        processNonKey(line, false);
         return;
       }
       if (state == State.RequireTopKey && currentIndent > 0) {
         throw new IllegalStateException("Require top level key at line:" + currentLine + " [" + line + "]");
       }
 
-      // must be a key - would expect explicit multiline otherwise
       final Key key = new Key(currentIndent, trimKey(line.substring(0, pos)));
       popKeys(currentIndent);
       keyStack.push(key);
 
-      // look at the remainder of the line
       final String remaining = line.substring(pos + 1);
       final String trimmedValue = remaining.trim();
       if (trimmedValue.startsWith("|")) {
         multilineStart(multiLineTrimMode(trimmedValue));
-
-      } else if (trimmedValue.startsWith("-")) {
+      } else if ("-".equals(trimmedValue) || trimmedValue.startsWith("- ")) {
         listStart(multiLineTrimMode(trimmedValue));
       } else if (trimmedValue.isEmpty() || trimmedValue.startsWith("#")) {
-        // empty or comment
         state = State.KeyOrValue;
       } else {
-        // simple key value
         addKeyVal(trimValue(remaining.trim()));
+      }
+    }
+
+    private void processObjectListItem(String afterDash) {
+      popKeys(currentIndent);
+      final String counterKey = fullKey() + ":" + currentIndent;
+      final int index = listCounters.compute(counterKey, (k, v) -> v == null ? 0 : v + 1);
+      keyStack.push(new Key(currentIndent, "[" + index + "]"));
+
+      final int colonPos = afterDash.indexOf(':');
+      final String keyName = trimKey(afterDash.substring(0, colonPos));
+      final String remaining = afterDash.substring(colonPos + 1);
+      final String trimmedValue = remaining.trim();
+      keyStack.push(new Key(currentIndent + 1, keyName));
+      if (trimmedValue.startsWith("|")) {
+        multilineStart(multiLineTrimMode(trimmedValue));
+      } else if ("-".equals(trimmedValue) || trimmedValue.startsWith("- ")) {
+        listStart(multiLineTrimMode(trimmedValue));
+      } else if (trimmedValue.isEmpty() || trimmedValue.startsWith("#")) {
+        state = State.KeyOrValue;
+      } else {
+        addKeyVal(trimValue(trimmedValue));
       }
     }
 
@@ -285,6 +317,7 @@ final class YamlLoaderSimple implements YamlLoader {
     private boolean newDocument(String line) {
       if (line.startsWith("---")) {
         keyStack.clear();
+        listCounters.clear();
         return true;
       }
       return false;
@@ -302,7 +335,8 @@ final class YamlLoaderSimple implements YamlLoader {
       if (value.startsWith("\"")) {
         return unquoteValue('"', value);
       }
-      int commentPos = value.indexOf('#');
+      //yaml requires that comments have a space from the value
+      int commentPos = value.indexOf(" #");
       if (commentPos > -1) {
         return value.substring(0, commentPos).trim();
       }
@@ -315,12 +349,16 @@ final class YamlLoaderSimple implements YamlLoader {
     }
 
     private String fullKey() {
-      StringJoiner fullKey = new StringJoiner(".");
+      StringBuilder sb = new StringBuilder();
       Iterator<Key> it = keyStack.descendingIterator();
       while (it.hasNext()) {
-        fullKey.add(it.next().key());
+        String k = it.next().key();
+        if (sb.length() > 0 && !k.startsWith("[")) {
+          sb.append('.');
+        }
+        sb.append(k);
       }
-      return fullKey.toString();
+      return sb.toString();
     }
 
     private void popKeys(int indent) {

--- a/avaje-config/src/main/java/io/avaje/config/YamlLoaderSnake.java
+++ b/avaje-config/src/main/java/io/avaje/config/YamlLoaderSnake.java
@@ -2,9 +2,10 @@ package io.avaje.config;
 
 import java.io.InputStream;
 import java.io.Reader;
-import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.jspecify.annotations.NullMarked;
 import org.yaml.snakeyaml.Yaml;
@@ -60,9 +61,30 @@ final class YamlLoaderSnake implements YamlLoader {
         Object val = entry.getValue();
         if (val instanceof Map) {
           loadMap((Map<String, Object>) val, key);
+        } else if (val instanceof List) {
+          loadList((List<?>) val, key);
         } else {
           addScalar(key, val);
         }
+      }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void loadList(List<?> list, String path) {
+      boolean hasObjects = list.stream().anyMatch(item -> item instanceof Map);
+      if (hasObjects) {
+        for (int i = 0; i < list.size(); i++) {
+          Object item = list.get(i);
+          if (item instanceof Map) {
+            loadMap((Map<String, Object>) item, path + "[" + i + "]");
+          } else {
+            addScalar(path + "[" + i + "]", item);
+          }
+        }
+      } else {
+        add(path, list.stream()
+            .map(item -> item == null ? "" : item.toString())
+            .collect(Collectors.joining(",")));
       }
     }
 
@@ -71,8 +93,6 @@ final class YamlLoaderSnake implements YamlLoader {
         add(key, (String) val);
       } else if (val instanceof Number || val instanceof Boolean) {
         add(key, val.toString());
-      } else if (val instanceof Collection<?>) {
-        add(key, String.join(",", (Iterable<String>) val));
       }
     }
 

--- a/avaje-config/src/test/java/io/avaje/config/YamlParserTest.java
+++ b/avaje-config/src/test/java/io/avaje/config/YamlParserTest.java
@@ -197,6 +197,56 @@ class YamlParserTest {
   }
 
   @Test
+  void parse_nestedList() {
+    parse_nestedList(parseYaml2("/yaml/nested-list.yaml"));
+    parse_nestedList(parseYaml("/yaml/nested-list.yaml"));
+  }
+
+  private void parse_nestedList(Map<String, String> map) {
+    assertThat(map).containsOnlyKeys(
+        "config.dev[0].source",
+        "config.dev[0].mapping[0].sourceKey",
+        "config.dev[0].mapping[0].envVar",
+        "config.dev[0].mapping[1].sourceKey",
+        "config.dev[0].mapping[1].envVar",
+        "config.dev[1].source",
+        "config.dev[1].assumed_role",
+        "config.dev[1].mapping[0].sourceKey",
+        "config.dev[1].mapping[0].envVar",
+        "config.qa[0].source",
+        "config.qa[0].mapping[0].sourceKey",
+        "config.qa[0].mapping[0].envVar");
+    assertThat(map.get("config.dev[0].source")).isEqualTo("path/to/config");
+    assertThat(map.get("config.dev[0].mapping[0].sourceKey")).isEqualTo("name");
+    assertThat(map.get("config.dev[0].mapping[0].envVar")).isEqualTo("app.name");
+    assertThat(map.get("config.dev[0].mapping[1].sourceKey")).isEqualTo("auth");
+    assertThat(map.get("config.dev[0].mapping[1].envVar")).isEqualTo("app.auth");
+    assertThat(map.get("config.dev[1].source")).isEqualTo("path/to/dev-config2");
+    assertThat(map.get("config.dev[1].assumed_role")).isEqualTo("arn:some:role/cross-account-role");
+    assertThat(map.get("config.dev[1].mapping[0].sourceKey")).isEqualTo("username");
+    assertThat(map.get("config.dev[1].mapping[0].envVar")).isEqualTo("cross_username");
+    assertThat(map.get("config.qa[0].source")).isEqualTo("path/to/qa-config");
+    assertThat(map.get("config.qa[0].mapping[0].sourceKey")).isEqualTo("name");
+    assertThat(map.get("config.qa[0].mapping[0].envVar")).isEqualTo("app.name");
+  }
+
+  @Test
+  void parse_edgeCases() {
+    parse_edgeCases(parseYaml2("/yaml/edge-cases.yaml"));
+    parse_edgeCases(parseYaml("/yaml/edge-cases.yaml"));
+  }
+
+  private void parse_edgeCases(Map<String, String> map) {
+    assertThat(map).containsOnlyKeys("hex", "hex2", "neg", "negFloat", "negWithComment", "plainHash");
+    assertThat(map.get("hex")).isEqualTo("#FF0000");
+    assertThat(map.get("hex2")).isEqualTo("#00FF00");
+    assertThat(map.get("neg")).isEqualTo("-5");
+    assertThat(map.get("negFloat")).isEqualTo("-3.14");
+    assertThat(map.get("negWithComment")).isEqualTo("-42");
+    assertThat(map.get("plainHash")).isEqualTo("some#value");
+  }
+
+  @Test
   void parse_list() {
     var list =
         Map.of(

--- a/avaje-config/src/test/resources/yaml/edge-cases.yaml
+++ b/avaje-config/src/test/resources/yaml/edge-cases.yaml
@@ -1,0 +1,6 @@
+hex: '#FF0000'
+hex2: "#00FF00"
+neg: -5
+negFloat: -3.14
+negWithComment: -42 # this is negative forty-two
+plainHash: some#value

--- a/avaje-config/src/test/resources/yaml/nested-list.yaml
+++ b/avaje-config/src/test/resources/yaml/nested-list.yaml
@@ -1,0 +1,18 @@
+config:
+  dev:
+    - source: path/to/config
+      mapping:
+        - sourceKey: name
+          envVar: app.name
+        - sourceKey: auth
+          envVar: app.auth
+    - source: path/to/dev-config2
+      assumed_role: arn:some:role/cross-account-role
+      mapping:
+        - sourceKey: username
+          envVar: cross_username
+  qa:
+    - source: path/to/qa-config
+      mapping:
+        - sourceKey: name
+          envVar: app.name


### PR DESCRIPTION
 Improve simple YAML parser correctness and add nested object list support.

  -  Values like `neg: -5` were incorrectly triggering list-mode because the value started with -.
  - `#` in unquoted values incorrectly stripped as comment
  -  `YamlLoaderSnake` crashed on object lists
  -  Both parsers also now support lists of objects with full key indexing:

```yml
  config:
    dev:
      - source: path/to/config
        mapping:
          - sourceKey: name
            envVar: app.name
```
  Produces flat keys:
```
  config.dev[0].source = path/to/config
  config.dev[0].mapping[0].sourceKey = name
  config.dev[0].mapping[0].envVar = app.name
 ```